### PR TITLE
feat: add explicit prerelease tagging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,6 @@ Releases are automated via [GoReleaser](https://goreleaser.com/):
 
 - **Stable releases** — when a tag matching `v*.*.*` is pushed, CI runs tests and lint, then builds binaries for all platforms (Linux, macOS, Windows × AMD64, ARM64) and publishes to GitHub Releases with Debian/RPM packages.
 
-- **Beta (unstable)** — every push to `main` produces an immutable beta pre-release (e.g., `v1.1.0-beta.1`) with snapshot builds (tar.gz/zip archives only, no system packages).
+- **Preview (unstable)** — maintainers tag preview releases deliberately via `git sf release preview` (e.g., `v1.1.0-beta.1`). This produces snapshot builds (tar.gz/zip archives only, no system packages) for early testing. Preview tags are not created automatically on every push to `main`.
 
 Contributors don't need to run GoReleaser locally. Just open a PR, get it merged, and a maintainer will tag the release.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ semver versioning built in. Stop remembering the right sequence and focus on shi
 
 - **One command per action** — start, publish, finish, or discard a branch in a single step
 - **Semver releases** — tag `major`, `minor`, or `patch` releases directly from `main`
+- **Preview releases with configurable suffixes (beta, rc, alpha)**
 - **Hotfix from tags** — branch from the exact release, not from trunk, so no unreleased code leaks in
 - **Dry-run mode** — preview every git/gh command before it runs with `--dry-run`
 - **Three-layer config** — defaults, global (`~/.config/git-sf/config.yml`), and repo (`.sfconfig.yml`)
@@ -75,6 +76,7 @@ git sf init                        # create .sfconfig.yml with defaults
 git sf feature start my-feature    # branch from main
 git sf feature publish             # push + open PR
 git sf feature finish              # merge PR + clean up
+git sf release preview             # tag a preview release (e.g. v1.1.0-beta.1)
 git sf release minor               # tag v1.x.0
 ```
 
@@ -105,6 +107,8 @@ git sf feature discard             # close PR, delete branch, switch to main
 | `--title`    | `start`, `publish` | Override the auto-generated PR title (on `start`, requires `--draft-pr`) |
 | `--body`     | `publish`          | Set the PR description                          |
 | `--force`    | `finish`           | Skip CI check verification before merging       |
+| `--preview`  | `finish`           | Tag a preview release after merging             |
+| `--scope`    | `finish`           | Semver bump level for the preview tag (`major`, `minor`, `patch`) |
 | `--reason`   | `discard`          | Leave a comment on the closed PR explaining why |
 
 `start` checks out `main`, pulls latest, and creates the branch. If `--draft-pr` is passed (or `draft_pr_on_start` is
@@ -152,6 +156,19 @@ git sf release patch               # tag next patch version
 The command verifies that your local `main` is in sync with origin before tagging. If no tags exist yet, the first
 release starts at `v0.1.0`. The bump type argument is optional — when omitted, it uses your `default_release_bump`
 config (default: `minor`).
+
+### Preview Releases
+
+Tag a preview release from main:
+
+    git sf release preview                # uses default scope from config
+    git sf release preview --scope patch  # explicit bump
+    git sf release preview -m "message"   # annotated tag
+
+Or create a preview tag automatically after merging a feature:
+
+    git sf feature finish --preview
+    git sf feature finish --preview --scope minor
 
 ### Status
 
@@ -209,14 +226,17 @@ Configuration is merged from three layers (highest priority last):
 
 | Key                    | Default    | Description                                       |
 |------------------------|------------|---------------------------------------------------|
-| `main_branch`          | `main`     | The trunk branch name                             |
-| `tag_prefix`           | `v`        | Prefix for release tags (e.g. `v1.2.3`)           |
-| `feature_prefix`       | `feature/` | Prefix for feature branches                       |
-| `hotfix_prefix`        | `hotfix/`  | Prefix for hotfix branches                        |
-| `merge_strategy`       | `squash`   | PR merge strategy: `squash`, `merge`, or `rebase` |
-| `default_release_bump` | `minor`    | Default semver bump: `major`, `minor`, or `patch` |
-| `draft_pr_on_start`    | `false`    | Auto-create draft PR when starting a branch       |
-| `hotfix_auto_release`  | `false`    | Auto-tag patch release after `hotfix finish`      |
+| `main_branch`              | `main`     | The trunk branch name                             |
+| `tag_prefix`               | `v`        | Prefix for release tags (e.g. `v1.2.3`)           |
+| `feature_prefix`           | `feature/` | Prefix for feature branches                       |
+| `hotfix_prefix`            | `hotfix/`  | Prefix for hotfix branches                        |
+| `merge_strategy`           | `squash`   | PR merge strategy: `squash`, `merge`, or `rebase` |
+| `default_release_bump`     | `minor`    | Default semver bump: `major`, `minor`, or `patch` |
+| `draft_pr_on_start`        | `false`    | Auto-create draft PR when starting a branch       |
+| `hotfix_auto_release`      | `false`    | Auto-tag patch release after `hotfix finish`      |
+| `prerelease_enabled`       | `false`    | Enable preview release tagging                    |
+| `default_prerelease_bump`  | `minor`    | Default semver bump for preview releases          |
+| `prerelease_suffix`        | `beta`     | Suffix for preview tags (e.g. `beta`, `rc`, `alpha`) |
 
 Example `.sfconfig.yml`:
 
@@ -225,6 +245,9 @@ main_branch: main
 merge_strategy: squash
 default_release_bump: minor
 draft_pr_on_start: true
+prerelease_enabled: true
+prerelease_suffix: beta
+default_prerelease_bump: minor
 ```
 
 Run `git sf config` to inspect the resolved values and where each one comes from.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -140,14 +140,17 @@ var configEditCmd = &cobra.Command{
 		inherited := config.Merge(config.Defaults(), global)
 		cfg := config.Merge(inherited, repo)
 		defaults := ui.InitFormResult{
-			MainBranch:         cfg.MainBranch,
-			FeaturePrefix:      cfg.FeaturePrefix,
-			HotfixPrefix:       cfg.HotfixPrefix,
-			TagPrefix:          cfg.TagPrefix,
-			MergeStrategy:      cfg.MergeStrategy,
-			DefaultReleaseBump: cfg.DefaultReleaseBump,
-			DraftPR:            cfg.DraftPROnStart,
-			HotfixAutoRelease:  cfg.HotfixAutoRelease,
+			MainBranch:            cfg.MainBranch,
+			FeaturePrefix:         cfg.FeaturePrefix,
+			HotfixPrefix:          cfg.HotfixPrefix,
+			TagPrefix:             cfg.TagPrefix,
+			MergeStrategy:         cfg.MergeStrategy,
+			DefaultReleaseBump:    cfg.DefaultReleaseBump,
+			DraftPR:               cfg.DraftPROnStart,
+			HotfixAutoRelease:     cfg.HotfixAutoRelease,
+			PrereleaseEnabled:     cfg.PrereleaseEnabled,
+			DefaultPrereleaseBump: cfg.DefaultPrereleaseBump,
+			PrereleaseSuffix:      cfg.PrereleaseSuffix,
 		}
 
 		var partial config.PartialConfig
@@ -247,6 +250,12 @@ var configCmd = &cobra.Command{
 			func(c *config.PartialConfig) *bool { return c.DraftPROnStart })
 		printConfigBoolField(u, "hotfix_auto_release", cfg.HotfixAutoRelease, global, repo,
 			func(c *config.PartialConfig) *bool { return c.HotfixAutoRelease })
+		printConfigBoolField(u, "prerelease_enabled", cfg.PrereleaseEnabled, global, repo,
+			func(c *config.PartialConfig) *bool { return c.PrereleaseEnabled })
+		printConfigField(u, "default_prerelease_bump", cfg.DefaultPrereleaseBump, global, repo,
+			func(c *config.PartialConfig) string { return c.DefaultPrereleaseBump })
+		printConfigField(u, "prerelease_suffix", cfg.PrereleaseSuffix, global, repo,
+			func(c *config.PartialConfig) string { return c.PrereleaseSuffix })
 		u.Blank()
 
 		for _, w := range configWarnings {
@@ -304,6 +313,9 @@ func buildRepoConfigForEdit(inherited config.Config, existing *config.PartialCon
 	updated.DefaultReleaseBump = repoStringOverride(result.DefaultReleaseBump, inherited.DefaultReleaseBump, updated.DefaultReleaseBump)
 	updated.DraftPROnStart = repoBoolOverride(result.DraftPR, inherited.DraftPROnStart, updated.DraftPROnStart)
 	updated.HotfixAutoRelease = repoBoolOverride(result.HotfixAutoRelease, inherited.HotfixAutoRelease, updated.HotfixAutoRelease)
+	updated.DefaultPrereleaseBump = repoStringOverride(result.DefaultPrereleaseBump, inherited.DefaultPrereleaseBump, updated.DefaultPrereleaseBump)
+	updated.PrereleaseSuffix = repoStringOverride(result.PrereleaseSuffix, inherited.PrereleaseSuffix, updated.PrereleaseSuffix)
+	updated.PrereleaseEnabled = repoBoolOverride(result.PrereleaseEnabled, inherited.PrereleaseEnabled, updated.PrereleaseEnabled)
 
 	return updated
 }

--- a/cmd/feature.go
+++ b/cmd/feature.go
@@ -9,6 +9,7 @@ import (
 	"github.com/milis92/git-simple-flow/internal/release"
 	"github.com/milis92/git-simple-flow/internal/runner"
 	"github.com/milis92/git-simple-flow/internal/ui"
+	"github.com/milis92/git-simple-flow/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -88,6 +89,10 @@ var featureFinishCmd = &cobra.Command{
 
 		force, _ := cmd.Flags().GetBool("force")
 		scope, _ := cmd.Flags().GetString("scope")
+
+		if scope != "" && !version.ValidScope(scope) {
+			return fmt.Errorf("invalid scope: %q (must be major, minor, or patch)", scope)
+		}
 
 		var preview *bool
 		if cmd.Flags().Changed("preview") {

--- a/cmd/feature.go
+++ b/cmd/feature.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/milis92/git-simple-flow/internal/feature"
 	"github.com/milis92/git-simple-flow/internal/gh"
 	"github.com/milis92/git-simple-flow/internal/git"
+	"github.com/milis92/git-simple-flow/internal/release"
 	"github.com/milis92/git-simple-flow/internal/runner"
 	"github.com/milis92/git-simple-flow/internal/ui"
 	"github.com/spf13/cobra"
@@ -65,6 +68,14 @@ var featureFinishCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := loadConfig()
 		r := runner.NewRunner(dryRun, verbose)
+
+		releaseSvc := &release.Service{
+			Git:              git.New(r, "."),
+			UI:               newUI(),
+			Config:           cfg,
+			RunMessagePrompt: ui.RunMessagePrompt,
+		}
+
 		svc := &feature.Service{
 			Git:            git.New(r, "."),
 			GH:             gh.New(r),
@@ -72,9 +83,27 @@ var featureFinishCmd = &cobra.Command{
 			Config:         cfg,
 			RunTitlePrompt: ui.RunTitlePrompt,
 			RunProgress:    ui.RunProgress,
+			PreviewRelease: releaseSvc.PreviewReleaseCore,
 		}
+
 		force, _ := cmd.Flags().GetBool("force")
-		return svc.Finish(feature.FinishOpts{Force: force})
+		scope, _ := cmd.Flags().GetString("scope")
+
+		var preview *bool
+		if cmd.Flags().Changed("preview") {
+			val, _ := cmd.Flags().GetBool("preview")
+			preview = &val
+		}
+
+		if preview != nil && !*preview && scope != "" {
+			return fmt.Errorf("conflicting flags: --preview=false and --scope cannot be used together")
+		}
+
+		return svc.Finish(feature.FinishOpts{
+			Force:   force,
+			Preview: preview,
+			Scope:   scope,
+		})
 	},
 }
 
@@ -104,6 +133,8 @@ func init() {
 	featurePublishCmd.Flags().String("title", "", "PR title (defaults to humanized branch name)")
 	featurePublishCmd.Flags().String("body", "", "PR body/description")
 	featureFinishCmd.Flags().Bool("force", false, "skip PR checks validation")
+	featureFinishCmd.Flags().Bool("preview", false, "create a preview tag after merge")
+	featureFinishCmd.Flags().String("scope", "", "bump scope for preview tag: major, minor, or patch")
 	featureDiscardCmd.Flags().String("reason", "", "comment to leave on the closed PR")
 
 	featureCmd.AddCommand(featureStartCmd)

--- a/cmd/release_preview.go
+++ b/cmd/release_preview.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/milis92/git-simple-flow/internal/git"
+	"github.com/milis92/git-simple-flow/internal/release"
+	"github.com/milis92/git-simple-flow/internal/runner"
+	"github.com/milis92/git-simple-flow/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// releasePreviewCmd tags and pushes a preview release from main.
+var releasePreviewCmd = &cobra.Command{
+	Use:   "preview",
+	Short: "Tag and push a preview release from main",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := loadConfig()
+		r := runner.NewRunner(dryRun, verbose)
+		svc := &release.Service{
+			Git:              git.New(r, "."),
+			UI:               newUI(),
+			Config:           cfg,
+			RunMessagePrompt: ui.RunMessagePrompt,
+		}
+
+		scope, _ := cmd.Flags().GetString("scope")
+		message, _ := cmd.Flags().GetString("message")
+		return svc.PreviewRelease(scope, message)
+	},
+}
+
+func init() {
+	releasePreviewCmd.Flags().String("scope", "", "bump scope: major, minor, or patch (default from config)")
+	releasePreviewCmd.Flags().StringP("message", "m", "", "tag message (prompted if interactive and not provided)")
+	releaseCmd.AddCommand(releasePreviewCmd)
+}

--- a/docs/simple-flow.md
+++ b/docs/simple-flow.md
@@ -7,7 +7,7 @@ It keeps the single-trunk simplicity of GitHub Flow but adds structured hotfix p
 release branches, develop branches, or feature flags.
 You work on feature branches, merge back to `main`, and tag a release when you are ready — with semver versioning built in.
 
-**Contents:** [Visual Overview](#visual-overview) · [Core Principles](#core-principles) · [Workflows](#workflows) · [Comparison](#how-simple-flow-compares) · [Deployment Strategy](#deployment-strategy) · [Edge Cases](#edge-cases) · [When to Use Something Else](#when-to-use-something-else)
+**Contents:** [Visual Overview](#visual-overview) · [Core Principles](#core-principles) · [Workflows](#workflows) · [Preview Releases](#preview-release-workflow) · [Comparison](#how-simple-flow-compares) · [Deployment Strategy](#deployment-strategy) · [Edge Cases](#edge-cases) · [When to Use Something Else](#when-to-use-something-else)
 
 ## Visual Overview
 
@@ -70,10 +70,14 @@ long-lived branches other than `main`.
    git sf feature finish
    ```
 
-5. **Optionally cut a release.** If this feature is worth shipping on its own, tag it.
+5. **Optionally cut a release.** If this feature is worth shipping on its own, tag it. For a full stable release, use
+   `git sf release`. To tag a preview release instead (e.g. for beta testing before the final release), pass `--preview`
+   to `finish`:
 
    ```bash
-   git sf release minor
+   git sf release minor                       # stable release
+   git sf feature finish --preview            # preview release after merging
+   git sf feature finish --preview --scope minor  # explicit bump level
    ```
 
 > [!TIP]
@@ -165,6 +169,44 @@ A release is not a branch. It is a point-in-time snapshot of `main` captured as 
 > There are no release branches. If a release needs a fix after the fact, that is a hotfix — branch from the
 > tag, fix it, and cut a patch release.
 
+### Preview Release Workflow
+
+A preview release is a semver pre-release tag (e.g. `v1.3.0-beta.1`) used to signal that the next version is
+available for early testing without committing to a stable release. Preview tags follow the same versioning rules as
+stable releases — the bump level controls which segment increments — but they include a configurable suffix
+(`beta`, `rc`, `alpha`, etc.).
+
+1. **Tag a preview release directly from main:**
+
+   ```bash
+   git sf release preview                # uses default_prerelease_bump from config
+   git sf release preview --scope patch  # explicit bump level
+   git sf release preview -m "message"   # create an annotated tag
+   ```
+
+2. **Or trigger a preview tag as part of feature finish:**
+
+   ```bash
+   git sf feature finish --preview
+   git sf feature finish --preview --scope minor
+   ```
+
+   This merges the PR and then immediately creates the preview tag on the resulting `main` commit.
+
+3. **Follow up with a stable release** when you are satisfied the preview is good:
+
+   ```bash
+   git sf release minor
+   ```
+
+> [!TIP]
+> Configure the suffix and default bump in `.sfconfig.yml`:
+> ```yaml
+> prerelease_enabled: true
+> prerelease_suffix: rc
+> default_prerelease_bump: minor
+> ```
+
 ## How Simple Flow Compares
 
 |                          | Git Flow                                      | GitHub Flow           | Simple Flow                         |
@@ -174,6 +216,7 @@ A release is not a branch. It is a point-in-time snapshot of `main` captured as 
 | **Feature branches**     | Long-lived                                    | Short-lived           | Flexible                            |
 | **Hotfix path**          | Branch from main tag, merge to main + develop | Just a PR             | Branch from tag, merge to main      |
 | **Built-in versioning**  | No                                            | No                    | Yes (semver tags)                   |
+| **Preview releases**     | Via release branches                          | No                    | Yes (`release preview` / `--preview`) |
 | **Feature flags needed** | Rarely                                        | Often                 | No                                  |
 | **Ceremony**             | High                                          | Low                   | Low                                 |
 | **Best for**             | Scheduled releases, multiple environments     | Continuous deployment | Trunk-based with versioned releases |
@@ -187,6 +230,7 @@ branches or infrastructure:
 |----------------------------------|--------------------------|--------------------------------------|------------------------------------------|
 | Push to a feature/hotfix branch  | **Dev**                  | Work in progress, single feature     | Developer testing, preview environments  |
 | Merge to `main`                  | **Beta / RC**            | All accepted work since the last tag | Integration testing, internal dogfooding |
+| Push a preview tag (`v*.*.*-<suffix>.*`) | **Beta / RC**   | Explicitly tagged preview snapshot   | Early adopters, opt-in beta channel      |
 | Push a semver tag (`v*.*.*`)     | **Production / Stable**  | Explicitly blessed snapshot          | End-user release                         |
 
 ### How it works
@@ -198,9 +242,10 @@ branches or infrastructure:
 **Dev builds** are triggered by any push to a feature or hotfix branch. These are throwaway artifacts for the developer
 or reviewer — deploy to a preview environment, run on a device, share with QA. They carry no version promise.
 
-**Beta builds** are triggered when a PR merges to `main`. At any point, the tip of `main` contains every accepted change
-since the last release. Treat this as a rolling "latest" or "release candidate" channel — suitable for internal
-dogfooding, staging environments, or beta testers who opt in to early builds.
+**Beta builds** are triggered by an explicit preview tag pushed via `git sf release preview` (or `git sf feature finish
+--preview`). Rather than treating every merge to `main` as a beta, Simple Flow lets maintainers deliberately tag a
+preview release — e.g. `v1.3.0-beta.1` — when the work on `main` is considered ready for early testing. This gives
+beta testers a stable, named snapshot rather than an ever-moving tip.
 
 **Production releases** are triggered when a semver tag is pushed. This is the only thing end users see. Because the tag
 points to a specific commit on `main`, you always know exactly what code is in a production build.
@@ -216,7 +261,7 @@ points to a specific commit on `main`, you always know exactly what code is in a
 on:
   push:
     branches: [main, 'feature/**', 'hotfix/**']
-    tags: ['v*.*.*']
+    tags: ['v*.*.*', 'v*.*.*-*']
 
 jobs:
   dev:
@@ -224,11 +269,12 @@ jobs:
     # Build preview artifact, deploy to dev environment ...
 
   beta:
-    if: github.ref == 'refs/heads/main'
-    # Build RC artifact, deploy to staging ...
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-')
+    # Build preview artifact, deploy to beta/RC channel ...
+    # Triggered by preview tags like v1.3.0-beta.1
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     # Build production artifact, publish to registry ...
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,28 +16,34 @@ import (
 
 // Config holds the fully resolved configuration with all fields populated.
 type Config struct {
-	MainBranch         string `yaml:"main_branch"`
-	TagPrefix          string `yaml:"tag_prefix"`
-	FeaturePrefix      string `yaml:"feature_prefix"`
-	HotfixPrefix       string `yaml:"hotfix_prefix"`
-	MergeStrategy      string `yaml:"merge_strategy"`
-	DefaultReleaseBump string `yaml:"default_release_bump"`
-	DraftPROnStart     bool   `yaml:"draft_pr_on_start"`
-	HotfixAutoRelease  bool   `yaml:"hotfix_auto_release"`
+	MainBranch            string `yaml:"main_branch"`
+	TagPrefix             string `yaml:"tag_prefix"`
+	FeaturePrefix         string `yaml:"feature_prefix"`
+	HotfixPrefix          string `yaml:"hotfix_prefix"`
+	MergeStrategy         string `yaml:"merge_strategy"`
+	DefaultReleaseBump    string `yaml:"default_release_bump"`
+	DraftPROnStart        bool   `yaml:"draft_pr_on_start"`
+	HotfixAutoRelease     bool   `yaml:"hotfix_auto_release"`
+	PrereleaseEnabled     bool   `yaml:"prerelease_enabled"`
+	DefaultPrereleaseBump string `yaml:"default_prerelease_bump"`
+	PrereleaseSuffix      string `yaml:"prerelease_suffix"`
 }
 
 // PartialConfig represents a sparse configuration from a single layer (global
 // or repo). String fields use zero values to indicate "not set". Bool fields
 // use pointers so that nil (not set) is distinguishable from false.
 type PartialConfig struct {
-	MainBranch         string `yaml:"main_branch,omitempty"`
-	TagPrefix          string `yaml:"tag_prefix,omitempty"`
-	FeaturePrefix      string `yaml:"feature_prefix,omitempty"`
-	HotfixPrefix       string `yaml:"hotfix_prefix,omitempty"`
-	MergeStrategy      string `yaml:"merge_strategy,omitempty"`
-	DefaultReleaseBump string `yaml:"default_release_bump,omitempty"`
-	DraftPROnStart     *bool  `yaml:"draft_pr_on_start,omitempty"`
-	HotfixAutoRelease  *bool  `yaml:"hotfix_auto_release,omitempty"`
+	MainBranch            string `yaml:"main_branch,omitempty"`
+	TagPrefix             string `yaml:"tag_prefix,omitempty"`
+	FeaturePrefix         string `yaml:"feature_prefix,omitempty"`
+	HotfixPrefix          string `yaml:"hotfix_prefix,omitempty"`
+	MergeStrategy         string `yaml:"merge_strategy,omitempty"`
+	DefaultReleaseBump    string `yaml:"default_release_bump,omitempty"`
+	DraftPROnStart        *bool  `yaml:"draft_pr_on_start,omitempty"`
+	HotfixAutoRelease     *bool  `yaml:"hotfix_auto_release,omitempty"`
+	PrereleaseEnabled     *bool  `yaml:"prerelease_enabled,omitempty"`
+	DefaultPrereleaseBump string `yaml:"default_prerelease_bump,omitempty"`
+	PrereleaseSuffix      string `yaml:"prerelease_suffix,omitempty"`
 }
 
 func isValidMergeStrategy(value string) bool {
@@ -56,6 +62,18 @@ func isValidReleaseBump(value string) bool {
 	default:
 		return false
 	}
+}
+
+func isValidPrereleaseSuffix(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, c := range value {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 // Validate checks that enum-like fields contain valid values and that
@@ -80,20 +98,29 @@ func (c Config) Validate() error {
 	if c.TagPrefix == "" {
 		return fmt.Errorf("tag_prefix must not be empty")
 	}
+	if !isValidReleaseBump(c.DefaultPrereleaseBump) {
+		return fmt.Errorf("invalid default_prerelease_bump %q: must be minor, patch, or major", c.DefaultPrereleaseBump)
+	}
+	if !isValidPrereleaseSuffix(c.PrereleaseSuffix) {
+		return fmt.Errorf("invalid prerelease_suffix %q: must be non-empty lowercase alphanumeric", c.PrereleaseSuffix)
+	}
 	return nil
 }
 
 // Defaults returns the built-in default configuration.
 func Defaults() Config {
 	return Config{
-		MainBranch:         "main",
-		TagPrefix:          "v",
-		FeaturePrefix:      "feature/",
-		HotfixPrefix:       "hotfix/",
-		MergeStrategy:      "squash",
-		DefaultReleaseBump: "minor",
-		DraftPROnStart:     false,
-		HotfixAutoRelease:  false,
+		MainBranch:            "main",
+		TagPrefix:             "v",
+		FeaturePrefix:         "feature/",
+		HotfixPrefix:          "hotfix/",
+		MergeStrategy:         "squash",
+		DefaultReleaseBump:    "minor",
+		DraftPROnStart:        false,
+		HotfixAutoRelease:     false,
+		PrereleaseEnabled:     false,
+		DefaultPrereleaseBump: "patch",
+		PrereleaseSuffix:      "beta",
 	}
 }
 
@@ -149,6 +176,25 @@ func SanitizePartial(cfg *PartialConfig) (*PartialConfig, []error) {
 		sanitized.DefaultReleaseBump = ""
 	}
 
+	sanitized.DefaultPrereleaseBump = sanitizeStringField(sanitized.DefaultPrereleaseBump, "default_prerelease_bump", &warnings)
+	sanitized.PrereleaseSuffix = sanitizeStringField(sanitized.PrereleaseSuffix, "prerelease_suffix", &warnings)
+
+	if sanitized.DefaultPrereleaseBump != "" && !isValidReleaseBump(sanitized.DefaultPrereleaseBump) {
+		warnings = append(warnings, fmt.Errorf(
+			"invalid default_prerelease_bump %q: must be minor, patch, or major",
+			sanitized.DefaultPrereleaseBump,
+		))
+		sanitized.DefaultPrereleaseBump = ""
+	}
+
+	if sanitized.PrereleaseSuffix != "" && !isValidPrereleaseSuffix(sanitized.PrereleaseSuffix) {
+		warnings = append(warnings, fmt.Errorf(
+			"invalid prerelease_suffix %q: must be non-empty lowercase alphanumeric",
+			sanitized.PrereleaseSuffix,
+		))
+		sanitized.PrereleaseSuffix = ""
+	}
+
 	return &sanitized, warnings
 }
 
@@ -191,6 +237,15 @@ func Merge(base Config, layers ...*PartialConfig) Config {
 		}
 		if layer.HotfixAutoRelease != nil {
 			result.HotfixAutoRelease = *layer.HotfixAutoRelease
+		}
+		if layer.PrereleaseEnabled != nil {
+			result.PrereleaseEnabled = *layer.PrereleaseEnabled
+		}
+		if layer.DefaultPrereleaseBump != "" {
+			result.DefaultPrereleaseBump = layer.DefaultPrereleaseBump
+		}
+		if layer.PrereleaseSuffix != "" {
+			result.PrereleaseSuffix = layer.PrereleaseSuffix
 		}
 	}
 	return result
@@ -256,6 +311,9 @@ func UpdatePartialConfigFile(path string, cfg PartialConfig) error {
 	setStringField(root, "default_release_bump", cfg.DefaultReleaseBump)
 	setBoolField(root, "draft_pr_on_start", cfg.DraftPROnStart)
 	setBoolField(root, "hotfix_auto_release", cfg.HotfixAutoRelease)
+	setBoolField(root, "prerelease_enabled", cfg.PrereleaseEnabled)
+	setStringField(root, "default_prerelease_bump", cfg.DefaultPrereleaseBump)
+	setStringField(root, "prerelease_suffix", cfg.PrereleaseSuffix)
 
 	var out bytes.Buffer
 	enc := yaml.NewEncoder(&out)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,9 @@ func isValidReleaseBump(value string) bool {
 	}
 }
 
-func isValidPrereleaseSuffix(value string) bool {
+// IsValidPrereleaseSuffix reports whether value is a valid prerelease suffix
+// (non-empty, lowercase alphanumeric only).
+func IsValidPrereleaseSuffix(value string) bool {
 	if value == "" {
 		return false
 	}
@@ -101,7 +103,7 @@ func (c Config) Validate() error {
 	if !isValidReleaseBump(c.DefaultPrereleaseBump) {
 		return fmt.Errorf("invalid default_prerelease_bump %q: must be minor, patch, or major", c.DefaultPrereleaseBump)
 	}
-	if !isValidPrereleaseSuffix(c.PrereleaseSuffix) {
+	if !IsValidPrereleaseSuffix(c.PrereleaseSuffix) {
 		return fmt.Errorf("invalid prerelease_suffix %q: must be non-empty lowercase alphanumeric", c.PrereleaseSuffix)
 	}
 	return nil
@@ -187,7 +189,7 @@ func SanitizePartial(cfg *PartialConfig) (*PartialConfig, []error) {
 		sanitized.DefaultPrereleaseBump = ""
 	}
 
-	if sanitized.PrereleaseSuffix != "" && !isValidPrereleaseSuffix(sanitized.PrereleaseSuffix) {
+	if sanitized.PrereleaseSuffix != "" && !IsValidPrereleaseSuffix(sanitized.PrereleaseSuffix) {
 		warnings = append(warnings, fmt.Errorf(
 			"invalid prerelease_suffix %q: must be non-empty lowercase alphanumeric",
 			sanitized.PrereleaseSuffix,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -447,3 +447,133 @@ func TestValidateEmptyPrefixes(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultsIncludesPrereleaseFields(t *testing.T) {
+	cfg := Defaults()
+	if cfg.PrereleaseEnabled {
+		t.Error("PrereleaseEnabled should default to false")
+	}
+	if cfg.DefaultPrereleaseBump != "patch" {
+		t.Errorf("DefaultPrereleaseBump = %q, want %q", cfg.DefaultPrereleaseBump, "patch")
+	}
+	if cfg.PrereleaseSuffix != "beta" {
+		t.Errorf("PrereleaseSuffix = %q, want %q", cfg.PrereleaseSuffix, "beta")
+	}
+}
+
+func TestMergePrereleaseFields(t *testing.T) {
+	base := Defaults()
+	global := &PartialConfig{PrereleaseSuffix: "rc"}
+	repo := &PartialConfig{PrereleaseEnabled: boolPtr(true), DefaultPrereleaseBump: "minor"}
+	result := Merge(base, global, repo)
+	if !result.PrereleaseEnabled {
+		t.Error("PrereleaseEnabled should be true (from repo)")
+	}
+	if result.DefaultPrereleaseBump != "minor" {
+		t.Errorf("DefaultPrereleaseBump = %q, want %q (from repo)", result.DefaultPrereleaseBump, "minor")
+	}
+	if result.PrereleaseSuffix != "rc" {
+		t.Errorf("PrereleaseSuffix = %q, want %q (from global)", result.PrereleaseSuffix, "rc")
+	}
+}
+
+func TestSanitizePartialRejectsInvalidPrereleaseSuffix(t *testing.T) {
+	tests := []struct {
+		name   string
+		suffix string
+	}{
+		{"uppercase", "BETA"},
+		{"dash", "be-ta"},
+		{"dot", "be.ta"},
+		{"spaces", "  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &PartialConfig{PrereleaseSuffix: tt.suffix}
+			sanitized, warnings := SanitizePartial(cfg)
+			if sanitized.PrereleaseSuffix != "" {
+				t.Errorf("PrereleaseSuffix should be cleared, got %q", sanitized.PrereleaseSuffix)
+			}
+			if len(warnings) == 0 {
+				t.Error("expected a warning for invalid suffix")
+			}
+		})
+	}
+}
+
+func TestSanitizePartialAcceptsValidPrereleaseSuffix(t *testing.T) {
+	for _, suffix := range []string{"beta", "rc", "alpha", "dev1"} {
+		cfg := &PartialConfig{PrereleaseSuffix: suffix}
+		sanitized, warnings := SanitizePartial(cfg)
+		if sanitized.PrereleaseSuffix != suffix {
+			t.Errorf("PrereleaseSuffix = %q, want %q", sanitized.PrereleaseSuffix, suffix)
+		}
+		for _, w := range warnings {
+			if w.Error() != "" {
+				t.Errorf("unexpected warning for valid suffix %q: %v", suffix, w)
+			}
+		}
+	}
+}
+
+func TestSanitizePartialRejectsInvalidPrereleaseBump(t *testing.T) {
+	cfg := &PartialConfig{DefaultPrereleaseBump: "tiny"}
+	sanitized, warnings := SanitizePartial(cfg)
+	if sanitized.DefaultPrereleaseBump != "" {
+		t.Errorf("DefaultPrereleaseBump should be cleared, got %q", sanitized.DefaultPrereleaseBump)
+	}
+	found := false
+	for _, w := range warnings {
+		if w != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a warning for invalid bump")
+	}
+}
+
+func TestValidateRejectsInvalidPrereleaseSuffix(t *testing.T) {
+	cfg := Defaults()
+	cfg.PrereleaseSuffix = ""
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() should fail with empty prerelease_suffix")
+	}
+}
+
+func TestValidateRejectsInvalidPrereleaseBump(t *testing.T) {
+	cfg := Defaults()
+	cfg.DefaultPrereleaseBump = "tiny"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() should fail with invalid default_prerelease_bump")
+	}
+}
+
+func TestUpdatePartialConfigFilePrereleaseFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	if err := UpdatePartialConfigFile(path, PartialConfig{
+		PrereleaseSuffix:      "rc",
+		DefaultPrereleaseBump: "minor",
+		PrereleaseEnabled:     boolPtr(true),
+	}); err != nil {
+		t.Fatalf("UpdatePartialConfigFile() error = %v", err)
+	}
+
+	loaded, err := LoadFromFile(path)
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+	if loaded.PrereleaseSuffix != "rc" {
+		t.Errorf("PrereleaseSuffix = %q, want %q", loaded.PrereleaseSuffix, "rc")
+	}
+	if loaded.DefaultPrereleaseBump != "minor" {
+		t.Errorf("DefaultPrereleaseBump = %q, want %q", loaded.DefaultPrereleaseBump, "minor")
+	}
+	if loaded.PrereleaseEnabled == nil || !*loaded.PrereleaseEnabled {
+		t.Error("PrereleaseEnabled should be true")
+	}
+}

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -25,6 +25,7 @@ type Service struct {
 	Config         config.Config
 	RunTitlePrompt func(string, bool) (ui.InputPromptResult, error)
 	RunProgress    func(string, string, []ui.StepDef, func(context.Context, ui.StepCallbacks) error) error
+	PreviewRelease func(scope, message string) error
 }
 
 // StartOpts configures feature branch creation.
@@ -47,6 +48,54 @@ type PublishOpts struct {
 type FinishOpts struct {
 	// Force skips CI check verification before merging.
 	Force bool
+	// Preview controls whether a preview tag is created after merge.
+	// nil = use config default, true = force preview, false = skip preview.
+	Preview *bool
+	// Scope is the bump scope for the preview tag: major, minor, or patch.
+	Scope string
+}
+
+// shouldRunPreview decides whether to run the preview release step and whether
+// a failure should be a hard error. Explicit flags (--scope, --preview=true)
+// make failures hard errors; config-driven auto-preview makes failures soft warnings.
+func (s *Service) shouldRunPreview(opts FinishOpts) (run bool, hardFail bool) {
+	if opts.Scope != "" {
+		return true, true
+	}
+	if opts.Preview != nil {
+		if *opts.Preview {
+			return true, true
+		}
+		return false, false
+	}
+	if s.Config.PrereleaseEnabled {
+		return true, false
+	}
+	return false, false
+}
+
+// runPreviewIfNeeded runs the preview release step if conditions are met.
+// Hard-fail mode returns errors directly; soft-fail mode logs warnings.
+func (s *Service) runPreviewIfNeeded(opts FinishOpts) error {
+	run, hardFail := s.shouldRunPreview(opts)
+	if !run {
+		return nil
+	}
+	if s.PreviewRelease == nil {
+		if hardFail {
+			return fmt.Errorf("preview release requested but not configured")
+		}
+		return nil
+	}
+
+	err := s.PreviewRelease(opts.Scope, "")
+	if err != nil {
+		if hardFail {
+			return fmt.Errorf("preview release failed: %w", err)
+		}
+		s.UI.Warning(fmt.Sprintf("Preview release failed (non-blocking): %s", err))
+	}
+	return nil
 }
 
 // Start creates a new feature branch from main. It checks out main, pulls
@@ -234,7 +283,7 @@ func (s *Service) finishInteractive(branch string, opts FinishOpts, qGH *gh.GH) 
 	}
 
 	var merged bool
-	wf := workflow.FinishWorkflow(s.Git, s.GH, branch, s.Config.MainBranch, s.Config.MergeStrategy, opts.Force, &merged)
+	wf := workflow.FinishWorkflow(s.Git, s.GH, branch, s.Config.MainBranch, s.Config.MergeStrategy, opts.Force, &merged, len(defs))
 	if err := s.RunProgress("git sf feature finish", branch, defs, wf); err != nil {
 		return err
 	}
@@ -243,6 +292,11 @@ func (s *Service) finishInteractive(branch string, opts FinishOpts, qGH *gh.GH) 
 		s.UI.Warning("PR is queued or pending — re-run 'git sf feature finish' after merge completes")
 		return nil
 	}
+
+	if err := s.runPreviewIfNeeded(opts); err != nil {
+		return err
+	}
+
 	s.UI.Result("Feature complete!")
 	return nil
 }
@@ -319,6 +373,10 @@ func (s *Service) finishClassic(branch string, opts FinishOpts, qGH *gh.GH) erro
 		s.UI.Warning(fmt.Sprintf("Could not delete remote branch %s: %s", branch, err))
 	} else {
 		s.UI.Success("Deleted remote branch " + branch)
+	}
+
+	if err := s.runPreviewIfNeeded(opts); err != nil {
+		return err
 	}
 
 	s.UI.Result("Feature complete!")

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -369,6 +369,178 @@ func helperArgs(args []string) []string {
 	return nil
 }
 
+// --- Preview tagging tests ---
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestShouldRunPreview(t *testing.T) {
+	tests := []struct {
+		name              string
+		opts              FinishOpts
+		prereleaseEnabled bool
+		wantRun           bool
+		wantHardFail      bool
+	}{
+		{
+			name:         "scope implies preview with hard fail",
+			opts:         FinishOpts{Scope: "minor"},
+			wantRun:      true,
+			wantHardFail: true,
+		},
+		{
+			name:         "explicit preview=true with hard fail",
+			opts:         FinishOpts{Preview: boolPtr(true)},
+			wantRun:      true,
+			wantHardFail: true,
+		},
+		{
+			name:         "explicit preview=false opts out",
+			opts:         FinishOpts{Preview: boolPtr(false)},
+			wantRun:      false,
+			wantHardFail: false,
+		},
+		{
+			name:              "nil preview + config enabled = auto with soft fail",
+			opts:              FinishOpts{},
+			prereleaseEnabled: true,
+			wantRun:           true,
+			wantHardFail:      false,
+		},
+		{
+			name:              "nil preview + config disabled = skip",
+			opts:              FinishOpts{},
+			prereleaseEnabled: false,
+			wantRun:           false,
+			wantHardFail:      false,
+		},
+		{
+			name:         "scope takes precedence over preview=false",
+			opts:         FinishOpts{Scope: "patch", Preview: boolPtr(false)},
+			wantRun:      true,
+			wantHardFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.PrereleaseEnabled = tt.prereleaseEnabled
+
+			svc := &Service{Config: cfg}
+
+			gotRun, gotHardFail := svc.shouldRunPreview(tt.opts)
+			if gotRun != tt.wantRun {
+				t.Errorf("run = %v, want %v", gotRun, tt.wantRun)
+			}
+			if gotHardFail != tt.wantHardFail {
+				t.Errorf("hardFail = %v, want %v", gotHardFail, tt.wantHardFail)
+			}
+		})
+	}
+}
+
+func TestRunPreviewIfNeeded(t *testing.T) {
+	previewErr := errors.New("tag creation failed")
+
+	tests := []struct {
+		name           string
+		opts           FinishOpts
+		prerelease     bool
+		previewRelease func(string, string) error
+		wantErr        bool
+		wantErrMsg     string
+	}{
+		{
+			name: "hard fail returns error when preview fails",
+			opts: FinishOpts{Preview: boolPtr(true)},
+			previewRelease: func(_, _ string) error {
+				return previewErr
+			},
+			wantErr:    true,
+			wantErrMsg: "preview release failed: tag creation failed",
+		},
+		{
+			name:       "soft fail logs warning and returns nil",
+			opts:       FinishOpts{},
+			prerelease: true,
+			previewRelease: func(_, _ string) error {
+				return previewErr
+			},
+			wantErr: false,
+		},
+		{
+			name:           "nil PreviewRelease + hard fail returns error",
+			opts:           FinishOpts{Preview: boolPtr(true)},
+			previewRelease: nil,
+			wantErr:        true,
+			wantErrMsg:     "preview release requested but not configured",
+		},
+		{
+			name:           "nil PreviewRelease + soft fail returns nil",
+			opts:           FinishOpts{},
+			prerelease:     true,
+			previewRelease: nil,
+			wantErr:        false,
+		},
+		{
+			name: "successful preview returns nil",
+			opts: FinishOpts{Preview: boolPtr(true)},
+			previewRelease: func(_, _ string) error {
+				return nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "preview not run when disabled returns nil",
+			opts: FinishOpts{Preview: boolPtr(false)},
+			previewRelease: func(_, _ string) error {
+				t.Fatal("PreviewRelease should not be called when preview is disabled")
+				return nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "scope is forwarded to PreviewRelease",
+			opts: FinishOpts{Scope: "major"},
+			previewRelease: func(scope, _ string) error {
+				if scope != "major" {
+					t.Errorf("scope = %q, want %q", scope, "major")
+				}
+				return nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Defaults()
+			cfg.PrereleaseEnabled = tt.prerelease
+
+			u := ui.New()
+			u.Out = &bytes.Buffer{}
+
+			svc := &Service{
+				Config:         cfg,
+				UI:             u,
+				PreviewRelease: tt.previewRelease,
+			}
+
+			err := svc.runPreviewIfNeeded(tt.opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("runPreviewIfNeeded() error = nil, want error")
+				}
+				if tt.wantErrMsg != "" && err.Error() != tt.wantErrMsg {
+					t.Errorf("error = %q, want %q", err.Error(), tt.wantErrMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("runPreviewIfNeeded() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -135,6 +135,9 @@ func (g *Git) LatestTag(prefix string) (string, error) {
 		if err != nil {
 			continue
 		}
+		if v.IsPrerelease() {
+			continue
+		}
 		versions = append(versions, v)
 		tagMap[v.String()] = tag
 	}
@@ -167,6 +170,9 @@ func (g *Git) LatestTagOnBranch(prefix, ref string) (string, error) {
 		if err != nil {
 			continue
 		}
+		if v.IsPrerelease() {
+			continue
+		}
 		versions = append(versions, v)
 		tagMap[v.String()] = tag
 	}
@@ -178,6 +184,54 @@ func (g *Git) LatestTagOnBranch(prefix, ref string) (string, error) {
 	})
 	latest := versions[len(versions)-1]
 	return tagMap[latest.String()], nil
+}
+
+// LatestPreviewTag finds the preview tag with the highest counter matching
+// the given suffix and target base version, reachable from ref. Returns
+// empty string (not error) if no matching preview tags exist.
+func (g *Git) LatestPreviewTag(prefix, suffix, ref string, target version.Version) (string, error) {
+	pattern := prefix + "*-" + suffix + ".*"
+	out, err := g.run("tag", "-l", pattern, "--merged", ref)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", nil
+	}
+
+	var bestCounter int
+	var bestTag string
+
+	for _, tag := range strings.Split(out, "\n") {
+		v, err := version.Parse(strings.TrimPrefix(tag, prefix))
+		if err != nil {
+			continue
+		}
+		if v.Prerelease != suffix {
+			continue
+		}
+		if v.Major != target.Major || v.Minor != target.Minor || v.Patch != target.Patch {
+			continue
+		}
+		if bestTag == "" || v.PreBuild > bestCounter {
+			bestCounter = v.PreBuild
+			bestTag = tag
+		}
+	}
+
+	return bestTag, nil
+}
+
+// ListTags returns all tags matching the given pattern.
+func (g *Git) ListTags(pattern string) ([]string, error) {
+	out, err := g.run("tag", "-l", pattern)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
 }
 
 // TagExistsOnRemote checks whether a tag has been pushed to origin.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -115,6 +115,14 @@ func (g *Git) DeleteLocalTag(name string) error {
 	return err
 }
 
+// ReplaceTagAnnotated atomically replaces an existing tag with an annotated
+// tag bearing the given message. If the command fails the original tag is
+// preserved because git applies -f only on success.
+func (g *Git) ReplaceTagAnnotated(name, message string) error {
+	_, err := g.run("tag", "-a", "-f", name, "-m", message)
+	return err
+}
+
 // PushTag pushes a single tag to origin.
 func (g *Git) PushTag(name string) error {
 	_, err := g.run("push", "origin", name)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -109,6 +109,12 @@ func (g *Git) TagAnnotated(name, message string) error {
 	return err
 }
 
+// DeleteLocalTag removes a tag from the local repository.
+func (g *Git) DeleteLocalTag(name string) error {
+	_, err := g.run("tag", "-d", name)
+	return err
+}
+
 // PushTag pushes a single tag to origin.
 func (g *Git) PushTag(name string) error {
 	_, err := g.run("push", "origin", name)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -248,6 +248,18 @@ func (g *Git) ListTags(pattern string) ([]string, error) {
 	return strings.Split(out, "\n"), nil
 }
 
+// ListTagsMerged returns tags matching the pattern that are reachable from ref.
+func (g *Git) ListTagsMerged(pattern, ref string) ([]string, error) {
+	out, err := g.run("tag", "-l", pattern, "--merged", ref)
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
 // TagExistsOnRemote checks whether a tag has been pushed to origin.
 // Returns false for local-only tags that were never published.
 func (g *Git) TagExistsOnRemote(tag string) (bool, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/milis92/git-simple-flow/internal/runner"
+	"github.com/milis92/git-simple-flow/internal/version"
 )
 
 func setupTestRepo(t *testing.T) string {
@@ -272,6 +273,51 @@ func TestForcePush(t *testing.T) {
 	}
 }
 
+func TestLatestTagSkipsPrerelease(t *testing.T) {
+	dir := setupTestRepo(t)
+	r := runner.NewRunner(false, false)
+	g := New(r, dir)
+
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.2"); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, err := g.LatestTag("v")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v1.0.0" {
+		t.Errorf("LatestTag() = %q, want %q (should skip prerelease tags)", tag, "v1.0.0")
+	}
+}
+
+func TestLatestTagOnBranchSkipsPrerelease(t *testing.T) {
+	dir := setupTestRepo(t)
+	r := runner.NewRunner(false, false)
+	g := New(r, dir)
+
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.0"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.1"); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, err := g.LatestTagOnBranch("v", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v1.0.0" {
+		t.Errorf("LatestTagOnBranch() = %q, want %q (should skip prerelease)", tag, "v1.0.0")
+	}
+}
+
 func TestResetSoftAndCommitWithMessage(t *testing.T) {
 	dir := setupTestRepo(t)
 	r := runner.NewRunner(false, false)
@@ -331,5 +377,83 @@ func TestResetSoftAndCommitWithMessage(t *testing.T) {
 	}
 	if msg != "squashed commit" {
 		t.Errorf("commit message = %q, want %q", msg, "squashed commit")
+	}
+}
+
+func TestLatestPreviewTag(t *testing.T) {
+	dir := setupTestRepo(t)
+	r := runner.NewRunner(false, false)
+	g := New(r, dir)
+
+	target := version.Version{Major: 1, Minor: 0, Patch: 1}
+
+	// No preview tags yet
+	tag, err := g.LatestPreviewTag("v", "beta", "HEAD", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "" {
+		t.Errorf("LatestPreviewTag() = %q, want empty when no tags exist", tag)
+	}
+
+	// Add preview tags
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.3"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.2"); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, err = g.LatestPreviewTag("v", "beta", "HEAD", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v1.0.1-beta.3" {
+		t.Errorf("LatestPreviewTag() = %q, want %q", tag, "v1.0.1-beta.3")
+	}
+}
+
+func TestLatestPreviewTagIgnoresStableAndWrongSuffix(t *testing.T) {
+	dir := setupTestRepo(t)
+	r := runner.NewRunner(false, false)
+	g := New(r, dir)
+
+	target := version.Version{Major: 1, Minor: 0, Patch: 1}
+
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-rc.5"); err != nil {
+		t.Fatal(err)
+	}
+
+	tag, err := g.LatestPreviewTag("v", "beta", "HEAD", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "" {
+		t.Errorf("LatestPreviewTag() = %q, want empty (no beta tags)", tag)
+	}
+}
+
+func TestLatestPreviewTagIgnoresDifferentTarget(t *testing.T) {
+	dir := setupTestRepo(t)
+	r := runner.NewRunner(false, false)
+	g := New(r, dir)
+
+	if _, err := r.Run("git", "-C", dir, "tag", "v1.0.1-beta.1"); err != nil {
+		t.Fatal(err)
+	}
+
+	target := version.Version{Major: 1, Minor: 0, Patch: 2}
+	tag, err := g.LatestPreviewTag("v", "beta", "HEAD", target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "" {
+		t.Errorf("LatestPreviewTag() = %q, want empty (wrong target)", tag)
 	}
 }

--- a/internal/hotfix/hotfix.go
+++ b/internal/hotfix/hotfix.go
@@ -453,7 +453,7 @@ func (s *Service) finishInteractive(branch string, opts FinishOpts, qGH *gh.GH) 
 	}
 
 	var merged bool
-	commonFinish := workflow.FinishWorkflow(s.Git, s.GH, branch, s.Config.MainBranch, s.Config.MergeStrategy, opts.Force, &merged)
+	commonFinish := workflow.FinishWorkflow(s.Git, s.GH, branch, s.Config.MainBranch, s.Config.MergeStrategy, opts.Force, &merged, len(defs))
 	err = s.RunProgress("git sf hotfix finish", branch, defs, commonFinish)
 	if err != nil {
 		return err

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -354,7 +354,7 @@ func (s *Service) PreviewReleaseCore(scope, message string) error {
 // findRecoverablePreviewTag returns the highest-counter local-only preview tag
 // on HEAD for the given target version, or "" if no recovery is needed.
 // A candidate is only recoverable if its counter exceeds every already-published
-// preview for the same target, ensuring monotonicity.
+// (remote) preview for the same target, ensuring monotonicity.
 func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (string, error) {
 	pattern := fmt.Sprintf("%s%s-%s.*", prefix, target.String(), suffix)
 	localTags, err := qGit.ListTags(pattern)
@@ -369,13 +369,23 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 
 	var best string
 	bestCounter := 0
+	highestPublished := 0
 
 	for _, tag := range localTags {
 		onRemote, err := qGit.TagExistsOnRemote(tag)
 		if err != nil {
 			return "", err
 		}
+
+		v, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
+		if parseErr != nil {
+			continue
+		}
+
 		if onRemote {
+			if v.PreBuild > highestPublished {
+				highestPublished = v.PreBuild
+			}
 			continue
 		}
 
@@ -387,10 +397,6 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 			continue
 		}
 
-		v, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
-		if parseErr != nil {
-			continue
-		}
 		if v.PreBuild > bestCounter {
 			best = tag
 			bestCounter = v.PreBuild
@@ -401,14 +407,9 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 		return "", nil
 	}
 
-	// Ensure the candidate's counter exceeds any already-published preview.
-	// LatestPreviewTag includes both local and remote tags merged into HEAD.
-	latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
-	if err == nil && latestPreview != "" {
-		v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix))
-		if parseErr == nil && bestCounter <= v.PreBuild {
-			return "", nil // stale: a higher or equal counter already exists
-		}
+	// Only recover if the candidate exceeds all published counters.
+	if bestCounter <= highestPublished {
+		return "", nil
 	}
 
 	return best, nil
@@ -429,12 +430,11 @@ func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, t
 		return false, nil
 	}
 
-	// If the caller supplied a message, recreate the tag as annotated.
+	// If the caller supplied a message, atomically replace the tag with
+	// an annotated version. Using -f ensures the original is preserved if
+	// the command fails (e.g. gpg signing unavailable).
 	if message != "" {
-		if err := s.Git.DeleteLocalTag(tag); err != nil {
-			return false, fmt.Errorf("could not remove local tag %s for re-annotation: %w", tag, err)
-		}
-		if err := s.Git.TagAnnotated(tag, message); err != nil {
+		if err := s.Git.ReplaceTagAnnotated(tag, message); err != nil {
 			return false, err
 		}
 	}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -183,24 +183,36 @@ func (s *Service) PreviewRelease(scope, message string) error {
 		}
 	}
 
-	// Compute the real counter so the confirmation prompt shows the
-	// actual tag name that PreviewReleaseCore will create.
-	counter := 1
-	latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
-	if err == nil && latestPreview != "" {
-		if v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix)); parseErr == nil {
-			counter = v.PreBuild + 1
-		}
+	// Check if a previous run left an unpushed local tag that
+	// PreviewReleaseCore will recover instead of creating a new one.
+	recoverable, recoverErr := findRecoverablePreviewTag(qGit, prefix, suffix, target)
+	if recoverErr != nil {
+		return recoverErr
 	}
 
-	previewTag := version.Version{
-		Major:      target.Major,
-		Minor:      target.Minor,
-		Patch:      target.Patch,
-		Prerelease: suffix,
-		PreBuild:   counter,
+	var newTag string
+	if recoverable != "" {
+		newTag = recoverable
+	} else {
+		// Compute the real counter so the confirmation prompt shows the
+		// actual tag name that PreviewReleaseCore will create.
+		counter := 1
+		latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
+		if err == nil && latestPreview != "" {
+			if v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix)); parseErr == nil {
+				counter = v.PreBuild + 1
+			}
+		}
+
+		previewTag := version.Version{
+			Major:      target.Major,
+			Minor:      target.Minor,
+			Patch:      target.Patch,
+			Prerelease: suffix,
+			PreBuild:   counter,
+		}
+		newTag = previewTag.FormatWithPrefix(prefix)
 	}
-	newTag := previewTag.FormatWithPrefix(prefix)
 
 	s.UI.Blank()
 	s.UI.Muted("Current: " + currentDisplay)
@@ -338,48 +350,71 @@ func (s *Service) PreviewReleaseCore(scope, message string) error {
 	return nil
 }
 
-// recoverLocalPreviewTag checks whether a local preview tag exists for the
-// given target version that was never pushed to origin (e.g. from a previous
-// failed push). If found, it pushes the tag and returns true. Returns false
-// if no recovery was needed.
-func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (bool, error) {
+// findRecoverablePreviewTag returns the highest-counter local-only preview tag
+// on HEAD for the given target version, or "" if no recovery is needed.
+func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (string, error) {
 	pattern := fmt.Sprintf("%s%s-%s.*", prefix, target.String(), suffix)
 	localTags, err := qGit.ListTags(pattern)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 
 	headSHA, err := qGit.RevParse("HEAD")
 	if err != nil {
-		return false, err
+		return "", err
 	}
+
+	var best string
+	bestCounter := 0
 
 	for _, tag := range localTags {
 		onRemote, err := qGit.TagExistsOnRemote(tag)
 		if err != nil {
-			return false, err
+			return "", err
 		}
-		if !onRemote {
-			// Only recover tags that point to HEAD. A stale local tag
-			// from a previous session must not be republished.
-			tagSHA, err := qGit.RevParse(tag + "^{commit}")
-			if err != nil {
-				return false, err
-			}
-			if tagSHA != headSHA {
-				s.UI.Warning(fmt.Sprintf("Stale local tag %s does not point to HEAD — skipping recovery", tag))
-				continue
-			}
+		if onRemote {
+			continue
+		}
 
-			s.UI.Info(fmt.Sprintf("Found unpushed local tag %s — pushing now", tag))
-			if err := s.Git.PushTag(tag); err != nil {
-				return false, err
-			}
-			s.UI.Success("Pushed recovered tag to origin")
-			s.UI.Result("Preview released " + tag)
-			return true, nil
+		tagSHA, err := qGit.RevParse(tag + "^{commit}")
+		if err != nil {
+			return "", err
+		}
+		if tagSHA != headSHA {
+			continue
+		}
+
+		v, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
+		if parseErr != nil {
+			continue
+		}
+		if v.PreBuild > bestCounter {
+			best = tag
+			bestCounter = v.PreBuild
 		}
 	}
 
-	return false, nil
+	return best, nil
+}
+
+// recoverLocalPreviewTag checks whether a local preview tag exists for the
+// given target version that was never pushed to origin (e.g. from a previous
+// failed push). If found, it pushes the highest-counter tag and returns true.
+// Returns false if no recovery was needed.
+func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (bool, error) {
+	tag, err := findRecoverablePreviewTag(qGit, prefix, suffix, target)
+	if err != nil {
+		return false, err
+	}
+	if tag == "" {
+		return false, nil
+	}
+
+	s.UI.Info(fmt.Sprintf("Found unpushed local tag %s — pushing now", tag))
+	if err := s.Git.PushTag(tag); err != nil {
+		return false, err
+	}
+	s.UI.Success("Pushed recovered tag to origin")
+	s.UI.Result("Preview released " + tag)
+	return true, nil
 }

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -354,10 +354,11 @@ func (s *Service) PreviewReleaseCore(scope, message string) error {
 // findRecoverablePreviewTag returns the highest-counter local-only preview tag
 // on HEAD for the given target version, or "" if no recovery is needed.
 // A candidate is only recoverable if its counter exceeds every already-published
-// (remote) preview for the same target, ensuring monotonicity.
+// (remote) preview reachable from HEAD, ensuring monotonicity. Using --merged HEAD
+// matches the scope of LatestPreviewTag so off-branch remote tags are ignored.
 func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (string, error) {
 	pattern := fmt.Sprintf("%s%s-%s.*", prefix, target.String(), suffix)
-	localTags, err := qGit.ListTags(pattern)
+	tags, err := qGit.ListTagsMerged(pattern, "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -371,15 +372,15 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 	bestCounter := 0
 	highestPublished := 0
 
-	for _, tag := range localTags {
-		onRemote, err := qGit.TagExistsOnRemote(tag)
-		if err != nil {
-			return "", err
-		}
-
+	for _, tag := range tags {
 		v, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
 		if parseErr != nil {
 			continue
+		}
+
+		onRemote, err := qGit.TagExistsOnRemote(tag)
+		if err != nil {
+			return "", err
 		}
 
 		if onRemote {
@@ -407,7 +408,8 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 		return "", nil
 	}
 
-	// Only recover if the candidate exceeds all published counters.
+	// Only recover if the candidate exceeds all published counters
+	// reachable from HEAD.
 	if bestCounter <= highestPublished {
 		return "", nil
 	}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -123,3 +123,237 @@ func (s *Service) Release(scope, message string) error {
 	s.UI.Result("Released " + newTag)
 	return nil
 }
+
+// PreviewRelease creates a prerelease tag on main with a confirmation prompt
+// and optional message prompt. It delegates to PreviewReleaseCore for the
+// actual tagging. This is the interactive entry point for `git sf release preview`.
+func (s *Service) PreviewRelease(scope, message string) error {
+	if err := git.CheckGitInstalled(); err != nil {
+		return err
+	}
+
+	qGit := s.Git.ForQuery()
+
+	if err := qGit.CheckIsRepo(); err != nil {
+		return err
+	}
+	if err := qGit.CheckOnBranch(s.Config.MainBranch); err != nil {
+		return err
+	}
+
+	if err := s.Git.Fetch(); err != nil {
+		return err
+	}
+
+	inSync, err := qGit.IsInSyncWithRemote(s.Config.MainBranch)
+	if err != nil {
+		return err
+	}
+	if !inSync {
+		return fmt.Errorf("local %s is not in sync with origin/%s — pull or push first", s.Config.MainBranch, s.Config.MainBranch)
+	}
+
+	// Resolve scope
+	if scope == "" {
+		scope = s.Config.DefaultPrereleaseBump
+	}
+
+	suffix := s.Config.PrereleaseSuffix
+	prefix := s.Config.TagPrefix
+
+	// Find latest stable tag and compute target
+	tag, err := qGit.LatestTagOnBranch(prefix, "HEAD")
+	var target version.Version
+	var currentDisplay string
+
+	if err != nil {
+		// No tags — first release
+		target = version.Version{Major: 0, Minor: 1, Patch: 0}
+		currentDisplay = "(no tags)"
+		s.UI.Info("No existing tags found. Starting at " + target.FormatWithPrefix(prefix))
+	} else {
+		current, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
+		if parseErr != nil {
+			return parseErr
+		}
+		currentDisplay = tag
+		target, err = current.Bump(scope)
+		if err != nil {
+			return err
+		}
+	}
+
+	previewTag := version.Version{
+		Major:      target.Major,
+		Minor:      target.Minor,
+		Patch:      target.Patch,
+		Prerelease: suffix,
+		PreBuild:   1, // placeholder for display
+	}
+	newTag := previewTag.FormatWithPrefix(prefix)
+
+	s.UI.Blank()
+	s.UI.Muted("Current: " + currentDisplay)
+	s.UI.Muted(fmt.Sprintf("Next:    %s (%s preview)", newTag, scope))
+	s.UI.Blank()
+
+	confirmed, err := s.UI.Confirm("Confirm preview release?")
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		s.UI.Muted("Aborted.")
+		return nil
+	}
+
+	s.UI.Blank()
+
+	if message == "" && s.UI.ShouldPrompt() {
+		var promptErr error
+		message, promptErr = s.RunMessagePrompt(newTag)
+		if promptErr != nil {
+			return promptErr
+		}
+	}
+
+	return s.PreviewReleaseCore(scope, message)
+}
+
+// PreviewReleaseCore creates a prerelease tag on main without any interactive
+// prompts. It is the public method called by both PreviewRelease and feature
+// finish. It handles retry recovery for previously failed tag pushes.
+func (s *Service) PreviewReleaseCore(scope, message string) error {
+	if err := git.CheckGitInstalled(); err != nil {
+		return err
+	}
+
+	qGit := s.Git.ForQuery()
+
+	if err := qGit.CheckIsRepo(); err != nil {
+		return err
+	}
+	if err := qGit.CheckOnBranch(s.Config.MainBranch); err != nil {
+		return err
+	}
+
+	if err := s.Git.Fetch(); err != nil {
+		return err
+	}
+
+	inSync, err := qGit.IsInSyncWithRemote(s.Config.MainBranch)
+	if err != nil {
+		return err
+	}
+	if !inSync {
+		return fmt.Errorf("local %s is not in sync with origin/%s — pull or push first", s.Config.MainBranch, s.Config.MainBranch)
+	}
+
+	// Resolve scope
+	if scope == "" {
+		scope = s.Config.DefaultPrereleaseBump
+	}
+
+	suffix := s.Config.PrereleaseSuffix
+	prefix := s.Config.TagPrefix
+
+	// Find latest stable tag and compute target
+	tag, err := qGit.LatestTagOnBranch(prefix, "HEAD")
+	var target version.Version
+
+	if err != nil {
+		// No tags — first release
+		target = version.Version{Major: 0, Minor: 1, Patch: 0}
+		s.UI.Info("No existing tags found. Starting at " + target.FormatWithPrefix(prefix))
+	} else {
+		current, parseErr := version.Parse(strings.TrimPrefix(tag, prefix))
+		if parseErr != nil {
+			return parseErr
+		}
+		target, err = current.Bump(scope)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Retry recovery: check if a local preview tag exists but wasn't pushed
+	recovered, err := s.recoverLocalPreviewTag(qGit, prefix, suffix, target)
+	if err != nil {
+		return err
+	}
+	if recovered {
+		return nil
+	}
+
+	// Find latest preview tag for this target to determine next counter
+	latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
+	if err != nil {
+		return err
+	}
+
+	counter := 1
+	if latestPreview != "" {
+		v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix))
+		if parseErr != nil {
+			return parseErr
+		}
+		counter = v.PreBuild + 1
+	}
+
+	next := version.Version{
+		Major:      target.Major,
+		Minor:      target.Minor,
+		Patch:      target.Patch,
+		Prerelease: suffix,
+		PreBuild:   counter,
+	}
+	newTag := next.FormatWithPrefix(prefix)
+
+	if message != "" {
+		if err := s.Git.TagAnnotated(newTag, message); err != nil {
+			return err
+		}
+	} else {
+		if err := s.Git.Tag(newTag); err != nil {
+			return err
+		}
+	}
+	s.UI.Success("Tagged " + newTag)
+
+	if err := s.Git.PushTag(newTag); err != nil {
+		return err
+	}
+	s.UI.Success("Pushed tag to origin")
+
+	s.UI.Result("Preview released " + newTag)
+	return nil
+}
+
+// recoverLocalPreviewTag checks whether a local preview tag exists for the
+// given target version that was never pushed to origin (e.g. from a previous
+// failed push). If found, it pushes the tag and returns true. Returns false
+// if no recovery was needed.
+func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (bool, error) {
+	pattern := fmt.Sprintf("%s%s-%s.*", prefix, target.String(), suffix)
+	localTags, err := qGit.ListTags(pattern)
+	if err != nil {
+		return false, err
+	}
+
+	for _, tag := range localTags {
+		onRemote, err := qGit.TagExistsOnRemote(tag)
+		if err != nil {
+			return false, err
+		}
+		if !onRemote {
+			s.UI.Info(fmt.Sprintf("Found unpushed local tag %s — pushing now", tag))
+			if err := s.Git.PushTag(tag); err != nil {
+				return false, err
+			}
+			s.UI.Success("Pushed recovered tag to origin")
+			s.UI.Result("Preview released " + tag)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -297,8 +297,9 @@ func (s *Service) PreviewReleaseCore(scope, message string) error {
 		}
 	}
 
-	// Retry recovery: check if a local preview tag exists but wasn't pushed
-	recovered, err := s.recoverLocalPreviewTag(qGit, prefix, suffix, target)
+	// Retry recovery: check if a local preview tag exists but wasn't pushed.
+	// Pass message so recovery can re-annotate the tag when a message is provided.
+	recovered, err := s.recoverLocalPreviewTag(qGit, prefix, suffix, target, message)
 	if err != nil {
 		return err
 	}
@@ -352,6 +353,8 @@ func (s *Service) PreviewReleaseCore(scope, message string) error {
 
 // findRecoverablePreviewTag returns the highest-counter local-only preview tag
 // on HEAD for the given target version, or "" if no recovery is needed.
+// A candidate is only recoverable if its counter exceeds every already-published
+// preview for the same target, ensuring monotonicity.
 func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (string, error) {
 	pattern := fmt.Sprintf("%s%s-%s.*", prefix, target.String(), suffix)
 	localTags, err := qGit.ListTags(pattern)
@@ -394,20 +397,46 @@ func findRecoverablePreviewTag(qGit *git.Git, prefix, suffix string, target vers
 		}
 	}
 
+	if best == "" {
+		return "", nil
+	}
+
+	// Ensure the candidate's counter exceeds any already-published preview.
+	// LatestPreviewTag includes both local and remote tags merged into HEAD.
+	latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
+	if err == nil && latestPreview != "" {
+		v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix))
+		if parseErr == nil && bestCounter <= v.PreBuild {
+			return "", nil // stale: a higher or equal counter already exists
+		}
+	}
+
 	return best, nil
 }
 
 // recoverLocalPreviewTag checks whether a local preview tag exists for the
 // given target version that was never pushed to origin (e.g. from a previous
 // failed push). If found, it pushes the highest-counter tag and returns true.
+// When message is non-empty, the local tag is recreated as an annotated tag
+// before pushing so user-supplied messages are not silently discarded.
 // Returns false if no recovery was needed.
-func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, target version.Version) (bool, error) {
+func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, target version.Version, message string) (bool, error) {
 	tag, err := findRecoverablePreviewTag(qGit, prefix, suffix, target)
 	if err != nil {
 		return false, err
 	}
 	if tag == "" {
 		return false, nil
+	}
+
+	// If the caller supplied a message, recreate the tag as annotated.
+	if message != "" {
+		if err := s.Git.DeleteLocalTag(tag); err != nil {
+			return false, fmt.Errorf("could not remove local tag %s for re-annotation: %w", tag, err)
+		}
+		if err := s.Git.TagAnnotated(tag, message); err != nil {
+			return false, err
+		}
 	}
 
 	s.UI.Info(fmt.Sprintf("Found unpushed local tag %s — pushing now", tag))

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -183,12 +183,22 @@ func (s *Service) PreviewRelease(scope, message string) error {
 		}
 	}
 
+	// Compute the real counter so the confirmation prompt shows the
+	// actual tag name that PreviewReleaseCore will create.
+	counter := 1
+	latestPreview, err := qGit.LatestPreviewTag(prefix, suffix, "HEAD", target)
+	if err == nil && latestPreview != "" {
+		if v, parseErr := version.Parse(strings.TrimPrefix(latestPreview, prefix)); parseErr == nil {
+			counter = v.PreBuild + 1
+		}
+	}
+
 	previewTag := version.Version{
 		Major:      target.Major,
 		Minor:      target.Minor,
 		Patch:      target.Patch,
 		Prerelease: suffix,
-		PreBuild:   1, // placeholder for display
+		PreBuild:   counter,
 	}
 	newTag := previewTag.FormatWithPrefix(prefix)
 
@@ -339,12 +349,28 @@ func (s *Service) recoverLocalPreviewTag(qGit *git.Git, prefix, suffix string, t
 		return false, err
 	}
 
+	headSHA, err := qGit.RevParse("HEAD")
+	if err != nil {
+		return false, err
+	}
+
 	for _, tag := range localTags {
 		onRemote, err := qGit.TagExistsOnRemote(tag)
 		if err != nil {
 			return false, err
 		}
 		if !onRemote {
+			// Only recover tags that point to HEAD. A stale local tag
+			// from a previous session must not be republished.
+			tagSHA, err := qGit.RevParse(tag + "^{commit}")
+			if err != nil {
+				return false, err
+			}
+			if tagSHA != headSHA {
+				s.UI.Warning(fmt.Sprintf("Stale local tag %s does not point to HEAD — skipping recovery", tag))
+				continue
+			}
+
 			s.UI.Info(fmt.Sprintf("Found unpushed local tag %s — pushing now", tag))
 			if err := s.Git.PushTag(tag); err != nil {
 				return false, err

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -257,6 +257,216 @@ func initReleaseRepo(t *testing.T) string {
 	return repoDir
 }
 
+func TestPreviewReleaseHappyPath(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewRelease("patch", ""); err != nil {
+		t.Fatalf("PreviewRelease() error = %v", err)
+	}
+
+	tagOutput := runGit(t, repoDir, "tag", "-l", "v0.1.1-beta.1")
+	if tagOutput != "v0.1.1-beta.1" {
+		t.Fatalf("expected tag v0.1.1-beta.1, got %q", tagOutput)
+	}
+}
+
+func TestPreviewReleaseFirstTagNoStable(t *testing.T) {
+	bareDir := t.TempDir()
+	runGit(t, bareDir, "init", "--bare", "-b", "main")
+	parentDir := t.TempDir()
+	repoDir := filepath.Join(parentDir, "work")
+	runGit(t, parentDir, "clone", bareDir, "work")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "init")
+	runGit(t, repoDir, "push", "origin", "main")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewRelease("patch", ""); err != nil {
+		t.Fatalf("PreviewRelease() error = %v", err)
+	}
+
+	tagOutput := runGit(t, repoDir, "tag", "-l", "v0.1.0-beta.1")
+	if tagOutput != "v0.1.0-beta.1" {
+		t.Fatalf("expected tag v0.1.0-beta.1, got %q", tagOutput)
+	}
+}
+
+func TestPreviewReleaseIncrementsCounter(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewRelease("patch", ""); err != nil {
+		t.Fatalf("first PreviewRelease() error = %v", err)
+	}
+	if err := svc.PreviewRelease("patch", ""); err != nil {
+		t.Fatalf("second PreviewRelease() error = %v", err)
+	}
+
+	tagOutput := runGit(t, repoDir, "tag", "-l", "v0.1.1-beta.2")
+	if tagOutput != "v0.1.1-beta.2" {
+		t.Fatalf("expected tag v0.1.1-beta.2, got %q", tagOutput)
+	}
+}
+
+func TestPreviewReleaseAnnotatedTag(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewRelease("patch", "Preview message"); err != nil {
+		t.Fatalf("PreviewRelease() error = %v", err)
+	}
+
+	objType := runGit(t, repoDir, "cat-file", "-t", "v0.1.1-beta.1")
+	if objType != "tag" {
+		t.Fatalf("expected annotated tag, got object type %q", objType)
+	}
+}
+
+func TestPreviewReleaseLightweightTag(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewRelease("patch", ""); err != nil {
+		t.Fatalf("PreviewRelease() error = %v", err)
+	}
+
+	objType := runGit(t, repoDir, "cat-file", "-t", "v0.1.1-beta.1")
+	if objType != "commit" {
+		t.Fatalf("expected lightweight tag, got object type %q", objType)
+	}
+}
+
+func TestPreviewReleaseNotOnMainErrors(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+	r := runner.NewRunner(false, false)
+	g := git.New(r, repoDir)
+	if err := g.CreateBranch("feature/test"); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              g,
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	err := svc.PreviewRelease("patch", "")
+	if err == nil {
+		t.Fatal("expected error when not on main")
+	}
+	if !strings.Contains(err.Error(), "must be on main") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStableReleaseIgnoresPreviewTags(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	r := runner.NewRunner(false, false)
+
+	runGit(t, repoDir, "tag", "v0.1.1-beta.1")
+	runGit(t, repoDir, "push", "origin", "v0.1.1-beta.1")
+
+	var out bytes.Buffer
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           config.Defaults(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.Release("patch", ""); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "v0.1.1") {
+		t.Fatalf("Release() output = %q, want v0.1.1", out.String())
+	}
+}
+
+func previewConfig() config.Config {
+	cfg := config.Defaults()
+	cfg.PrereleaseSuffix = "beta"
+	cfg.DefaultPrereleaseBump = "patch"
+	return cfg
+}
+
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -460,6 +460,149 @@ func TestStableReleaseIgnoresPreviewTags(t *testing.T) {
 	}
 }
 
+// TestRecoveryPushesLocalOnlyTagOnRerun verifies that rerunning
+// PreviewReleaseCore after a failed push recovers the existing local tag.
+func TestRecoveryPushesLocalOnlyTagOnRerun(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	// Create a local preview tag but do NOT push it (simulates failed push).
+	runGit(t, repoDir, "tag", "v0.1.1-beta.1")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewReleaseCore("patch", ""); err != nil {
+		t.Fatalf("PreviewReleaseCore() error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Found unpushed local tag v0.1.1-beta.1") {
+		t.Fatalf("expected recovery message, got %q", out.String())
+	}
+
+	// Verify the tag was pushed to origin.
+	remoteRefs := runGit(t, repoDir, "ls-remote", "--tags", "origin", "v0.1.1-beta.1")
+	if !strings.Contains(remoteRefs, "v0.1.1-beta.1") {
+		t.Fatalf("expected v0.1.1-beta.1 on remote, got %q", remoteRefs)
+	}
+}
+
+// TestRecoverySkipsStaleCounterBelowRemote verifies that a local-only tag
+// with a counter <= the highest published remote counter is not recovered.
+func TestRecoverySkipsStaleCounterBelowRemote(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	// Push beta.3 to remote (the highest published counter).
+	runGit(t, repoDir, "tag", "v0.1.1-beta.3")
+	runGit(t, repoDir, "push", "origin", "v0.1.1-beta.3")
+
+	// Leave beta.2 as local-only (stale leftover).
+	runGit(t, repoDir, "tag", "v0.1.1-beta.2")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewReleaseCore("patch", ""); err != nil {
+		t.Fatalf("PreviewReleaseCore() error = %v", err)
+	}
+
+	// Should NOT recover beta.2 — it should create beta.4 (next after beta.3).
+	if strings.Contains(out.String(), "Found unpushed local tag") {
+		t.Fatalf("should not recover stale tag, got %q", out.String())
+	}
+	tagOutput := runGit(t, repoDir, "tag", "-l", "v0.1.1-beta.4")
+	if tagOutput != "v0.1.1-beta.4" {
+		t.Fatalf("expected tag v0.1.1-beta.4, got %q", tagOutput)
+	}
+}
+
+// TestRecoveryPicksHighestCounter verifies that when multiple local-only
+// tags exist on HEAD, recovery selects the one with the highest counter.
+func TestRecoveryPicksHighestCounter(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	// Create two local-only preview tags (neither pushed).
+	runGit(t, repoDir, "tag", "v0.1.1-beta.1")
+	runGit(t, repoDir, "tag", "v0.1.1-beta.2")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewReleaseCore("patch", ""); err != nil {
+		t.Fatalf("PreviewReleaseCore() error = %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Found unpushed local tag v0.1.1-beta.2") {
+		t.Fatalf("expected recovery of beta.2 (highest), got %q", out.String())
+	}
+}
+
+// TestRecoveryReAnnotatesWhenMessageProvided verifies that recovery with a
+// non-empty message produces an annotated tag instead of the original lightweight one.
+func TestRecoveryReAnnotatesWhenMessageProvided(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	// Create a lightweight local-only preview tag.
+	runGit(t, repoDir, "tag", "v0.1.1-beta.1")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewReleaseCore("patch", "Recovery message"); err != nil {
+		t.Fatalf("PreviewReleaseCore() error = %v", err)
+	}
+
+	// Should be annotated now.
+	objType := runGit(t, repoDir, "cat-file", "-t", "v0.1.1-beta.1")
+	if objType != "tag" {
+		t.Fatalf("expected annotated tag after recovery, got object type %q", objType)
+	}
+
+	tagMsg := runGit(t, repoDir, "tag", "-l", "--format=%(contents:subject)", "v0.1.1-beta.1")
+	if tagMsg != "Recovery message" {
+		t.Fatalf("expected tag message %q, got %q", "Recovery message", tagMsg)
+	}
+}
+
 func previewConfig() config.Config {
 	cfg := config.Defaults()
 	cfg.PrereleaseSuffix = "beta"

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -603,6 +603,50 @@ func TestRecoveryReAnnotatesWhenMessageProvided(t *testing.T) {
 	}
 }
 
+// TestRecoveryIgnoresOffBranchRemoteTag verifies that an off-branch remote
+// preview tag with a higher counter does not suppress recovery of a valid
+// local-only tag on HEAD.
+func TestRecoveryIgnoresOffBranchRemoteTag(t *testing.T) {
+	repoDir := initReleaseRepo(t)
+
+	// Create beta.5 on a side branch and push it to remote.
+	runGit(t, repoDir, "checkout", "-b", "side")
+	if err := os.WriteFile(filepath.Join(repoDir, "side.txt"), []byte("side\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "side commit")
+	runGit(t, repoDir, "tag", "v0.1.1-beta.5")
+	runGit(t, repoDir, "push", "origin", "v0.1.1-beta.5")
+
+	// Switch back to main and create a local-only beta.4.
+	runGit(t, repoDir, "checkout", "main")
+	runGit(t, repoDir, "tag", "v0.1.1-beta.4")
+
+	var out bytes.Buffer
+	r := runner.NewRunner(false, false)
+	u := ui.New()
+	u.Out = &out
+	u.AutoConfirm = true
+
+	svc := &Service{
+		Git:              git.New(r, repoDir),
+		UI:               u,
+		Config:           previewConfig(),
+		RunMessagePrompt: ui.RunMessagePrompt,
+	}
+
+	if err := svc.PreviewReleaseCore("patch", ""); err != nil {
+		t.Fatalf("PreviewReleaseCore() error = %v", err)
+	}
+
+	// beta.4 should be recovered — the off-branch beta.5 is not reachable
+	// from main and should not suppress recovery.
+	if !strings.Contains(out.String(), "Found unpushed local tag v0.1.1-beta.4") {
+		t.Fatalf("expected recovery of beta.4, got %q", out.String())
+	}
+}
+
 func previewConfig() config.Config {
 	cfg := config.Defaults()
 	cfg.PrereleaseSuffix = "beta"

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -21,27 +21,33 @@ func validateNonEmpty(field string) func(string) error {
 // InitFormResult holds values collected by the configuration wizard,
 // used by both the init and config edit commands.
 type InitFormResult struct {
-	MainBranch         string
-	FeaturePrefix      string
-	HotfixPrefix       string
-	TagPrefix          string
-	MergeStrategy      string
-	DefaultReleaseBump string
-	DraftPR            bool
-	HotfixAutoRelease  bool
+	MainBranch            string
+	FeaturePrefix         string
+	HotfixPrefix          string
+	TagPrefix             string
+	MergeStrategy         string
+	DefaultReleaseBump    string
+	DraftPR               bool
+	HotfixAutoRelease     bool
+	PrereleaseEnabled     bool
+	DefaultPrereleaseBump string
+	PrereleaseSuffix      string
 }
 
 // InitFormResultFromDefaults creates an InitFormResult pre-filled from config defaults.
 func InitFormResultFromDefaults(cfg config.Config) InitFormResult {
 	return InitFormResult{
-		MainBranch:         cfg.MainBranch,
-		FeaturePrefix:      cfg.FeaturePrefix,
-		HotfixPrefix:       cfg.HotfixPrefix,
-		TagPrefix:          cfg.TagPrefix,
-		MergeStrategy:      cfg.MergeStrategy,
-		DefaultReleaseBump: cfg.DefaultReleaseBump,
-		DraftPR:            cfg.DraftPROnStart,
-		HotfixAutoRelease:  cfg.HotfixAutoRelease,
+		MainBranch:            cfg.MainBranch,
+		FeaturePrefix:         cfg.FeaturePrefix,
+		HotfixPrefix:          cfg.HotfixPrefix,
+		TagPrefix:             cfg.TagPrefix,
+		MergeStrategy:         cfg.MergeStrategy,
+		DefaultReleaseBump:    cfg.DefaultReleaseBump,
+		DraftPR:               cfg.DraftPROnStart,
+		HotfixAutoRelease:     cfg.HotfixAutoRelease,
+		PrereleaseEnabled:     cfg.PrereleaseEnabled,
+		DefaultPrereleaseBump: cfg.DefaultPrereleaseBump,
+		PrereleaseSuffix:      cfg.PrereleaseSuffix,
 	}
 }
 
@@ -49,15 +55,19 @@ func InitFormResultFromDefaults(cfg config.Config) InitFormResult {
 func (r InitFormResult) ToPartialConfig() config.PartialConfig {
 	draftPR := r.DraftPR
 	hotfixAutoRelease := r.HotfixAutoRelease
+	prereleaseEnabled := r.PrereleaseEnabled
 	return config.PartialConfig{
-		MainBranch:         r.MainBranch,
-		FeaturePrefix:      r.FeaturePrefix,
-		HotfixPrefix:       r.HotfixPrefix,
-		TagPrefix:          r.TagPrefix,
-		MergeStrategy:      r.MergeStrategy,
-		DefaultReleaseBump: r.DefaultReleaseBump,
-		DraftPROnStart:     &draftPR,
-		HotfixAutoRelease:  &hotfixAutoRelease,
+		MainBranch:            r.MainBranch,
+		FeaturePrefix:         r.FeaturePrefix,
+		HotfixPrefix:          r.HotfixPrefix,
+		TagPrefix:             r.TagPrefix,
+		MergeStrategy:         r.MergeStrategy,
+		DefaultReleaseBump:    r.DefaultReleaseBump,
+		DraftPROnStart:        &draftPR,
+		HotfixAutoRelease:     &hotfixAutoRelease,
+		PrereleaseEnabled:     &prereleaseEnabled,
+		DefaultPrereleaseBump: r.DefaultPrereleaseBump,
+		PrereleaseSuffix:      r.PrereleaseSuffix,
 	}
 }
 
@@ -100,7 +110,7 @@ func RunInitForm(defaults InitFormResult, branches []string) (InitFormResult, er
 				Title("Main branch").
 				Options(branchOptions...).
 				Value(&result.MainBranch),
-		).Title("Repository").Description("1/4"),
+		).Title("Repository").Description("1/5"),
 
 		huh.NewGroup(
 			huh.NewInput().
@@ -111,7 +121,7 @@ func RunInitForm(defaults InitFormResult, branches []string) (InitFormResult, er
 				Title("Hotfix branch prefix").
 				Value(&result.HotfixPrefix).
 				Validate(validateNonEmpty("hotfix prefix")),
-		).Title("Branches").Description("2/4"),
+		).Title("Branches").Description("2/5"),
 
 		huh.NewGroup(
 			huh.NewInput().
@@ -126,7 +136,7 @@ func RunInitForm(defaults InitFormResult, branches []string) (InitFormResult, er
 				Title("Default release bump").
 				Options(releaseBumpOptions...).
 				Value(&result.DefaultReleaseBump),
-		).Title("Tags & Merges").Description("3/4"),
+		).Title("Tags & Merges").Description("3/5"),
 
 		huh.NewGroup(
 			huh.NewConfirm().
@@ -135,7 +145,22 @@ func RunInitForm(defaults InitFormResult, branches []string) (InitFormResult, er
 			huh.NewConfirm().
 				Title("Auto-release patch after hotfix finish?").
 				Value(&result.HotfixAutoRelease),
-		).Title("Automation").Description("4/4"),
+		).Title("Automation").Description("4/5"),
+
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Auto-create preview tag on feature finish?").
+				Value(&result.PrereleaseEnabled),
+			huh.NewSelect[string]().
+				Title("Default prerelease bump").
+				Options(releaseBumpOptions...).
+				Value(&result.DefaultPrereleaseBump),
+			huh.NewInput().
+				Title("Prerelease suffix").
+				Description("e.g. beta, rc, alpha").
+				Value(&result.PrereleaseSuffix).
+				Validate(validateNonEmpty("prerelease suffix")),
+		).Title("Preview Releases").Description("5/5"),
 	).WithTheme(theme.HuhTheme())
 
 	err := form.Run()

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -159,7 +159,15 @@ func RunInitForm(defaults InitFormResult, branches []string) (InitFormResult, er
 				Title("Prerelease suffix").
 				Description("e.g. beta, rc, alpha").
 				Value(&result.PrereleaseSuffix).
-				Validate(validateNonEmpty("prerelease suffix")),
+				Validate(func(s string) error {
+					if strings.TrimSpace(s) == "" {
+						return fmt.Errorf("prerelease suffix cannot be empty")
+					}
+					if !config.IsValidPrereleaseSuffix(s) {
+						return fmt.Errorf("prerelease suffix must be lowercase alphanumeric (e.g. beta, rc, alpha)")
+					}
+					return nil
+				}),
 		).Title("Preview Releases").Description("5/5"),
 	).WithTheme(theme.HuhTheme())
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,19 +7,27 @@ import (
 	"strings"
 )
 
-// Version represents a semantic version with major, minor, and patch components.
+// Version represents a semantic version with major, minor, and patch components,
+// plus optional prerelease suffix and counter (e.g. "beta.1").
 type Version struct {
-	Major int
-	Minor int
-	Patch int
+	Major      int
+	Minor      int
+	Patch      int
+	Prerelease string // "beta", "rc", "alpha" — empty for stable
+	PreBuild   int    // 1, 2, 3 — counter after suffix
 }
 
 // Parse parses a semver string into a Version. The "v" prefix is optional
-// and will be stripped if present. The input must have exactly three
-// dot-separated numeric components (e.g. "1.2.3" or "v1.2.3").
+// and will be stripped if present. Accepts both stable ("1.2.3") and
+// prerelease ("1.2.3-beta.1") formats. Prerelease suffix must be lowercase
+// alphanumeric with a required numeric counter.
 func Parse(s string) (Version, error) {
 	s = strings.TrimPrefix(s, "v")
-	parts := strings.Split(s, ".")
+
+	// Split base from prerelease on first "-"
+	base, pre, _ := strings.Cut(s, "-")
+
+	parts := strings.Split(base, ".")
 	if len(parts) != 3 {
 		return Version{}, fmt.Errorf("invalid semver: %q", s)
 	}
@@ -35,24 +43,59 @@ func Parse(s string) (Version, error) {
 	if err != nil {
 		return Version{}, fmt.Errorf("invalid patch version: %q", parts[2])
 	}
-	return Version{Major: major, Minor: minor, Patch: patch}, nil
+
+	v := Version{Major: major, Minor: minor, Patch: patch}
+
+	if pre == "" {
+		return v, nil
+	}
+
+	// Parse prerelease: must be "suffix.counter"
+	preParts := strings.SplitN(pre, ".", 2)
+	if len(preParts) != 2 || preParts[0] == "" {
+		return Version{}, fmt.Errorf("invalid prerelease format: %q (expected suffix.counter)", pre)
+	}
+
+	for _, c := range preParts[0] {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return Version{}, fmt.Errorf("invalid prerelease suffix %q: must be lowercase alphanumeric", preParts[0])
+		}
+	}
+
+	counter, err := strconv.Atoi(preParts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid prerelease counter: %q", preParts[1])
+	}
+
+	v.Prerelease = preParts[0]
+	v.PreBuild = counter
+	return v, nil
 }
 
-// String formats the version as "Major.Minor.Patch".
+// String formats the version. Stable: "1.2.3". Prerelease: "1.2.3-beta.1".
 func (v Version) String() string {
+	if v.Prerelease != "" {
+		return fmt.Sprintf("%d.%d.%d-%s.%d", v.Major, v.Minor, v.Patch, v.Prerelease, v.PreBuild)
+	}
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// IsPrerelease reports whether this version has a prerelease suffix.
+func (v Version) IsPrerelease() bool {
+	return v.Prerelease != ""
 }
 
 // Bump returns a new Version with the given scope incremented.
 // Valid scopes are "major", "minor", and "patch". Higher components
 // reset lower ones to zero (e.g. bumping minor resets patch).
+// Prerelease fields are always cleared.
 // Returns an error for an invalid scope.
 func (v Version) Bump(scope string) (Version, error) {
 	switch scope {
 	case "major":
-		return Version{Major: v.Major + 1, Minor: 0, Patch: 0}, nil
+		return Version{Major: v.Major + 1}, nil
 	case "minor":
-		return Version{Major: v.Major, Minor: v.Minor + 1, Patch: 0}, nil
+		return Version{Major: v.Major, Minor: v.Minor + 1}, nil
 	case "patch":
 		return Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch + 1}, nil
 	default:
@@ -61,13 +104,14 @@ func (v Version) Bump(scope string) (Version, error) {
 }
 
 // FormatWithPrefix returns the version string with the given prefix prepended
-// (e.g. FormatWithPrefix("v") returns "v1.2.3").
+// (e.g. FormatWithPrefix("v") returns "v1.2.3" or "v1.2.3-beta.1").
 func (v Version) FormatWithPrefix(prefix string) string {
 	return prefix + v.String()
 }
 
-// LessThan reports whether v is strictly less than other,
-// comparing major, then minor, then patch.
+// LessThan reports whether v is strictly less than other, following semver
+// precedence: major, minor, patch, then prerelease < stable for the same
+// base version, then prerelease counter.
 func (v Version) LessThan(other Version) bool {
 	if v.Major != other.Major {
 		return v.Major < other.Major
@@ -75,7 +119,44 @@ func (v Version) LessThan(other Version) bool {
 	if v.Minor != other.Minor {
 		return v.Minor < other.Minor
 	}
-	return v.Patch < other.Patch
+	if v.Patch != other.Patch {
+		return v.Patch < other.Patch
+	}
+	// Same base version: prerelease < stable
+	if v.IsPrerelease() != other.IsPrerelease() {
+		return v.IsPrerelease()
+	}
+	// Both prerelease (or both stable): compare counter
+	return v.PreBuild < other.PreBuild
+}
+
+// BumpPrerelease computes the next prerelease version. The receiver is the
+// latest stable version. It bumps by scope to find the target stable version,
+// then finds the highest counter for that target+suffix in existingTags and
+// increments it (or starts at 1).
+func (v Version) BumpPrerelease(scope, suffix string, existingTags []Version) (Version, error) {
+	target, err := v.Bump(scope)
+	if err != nil {
+		return Version{}, err
+	}
+
+	maxCounter := 0
+	for _, t := range existingTags {
+		if t.Major == target.Major && t.Minor == target.Minor && t.Patch == target.Patch &&
+			t.Prerelease == suffix {
+			if t.PreBuild > maxCounter {
+				maxCounter = t.PreBuild
+			}
+		}
+	}
+
+	return Version{
+		Major:      target.Major,
+		Minor:      target.Minor,
+		Patch:      target.Patch,
+		Prerelease: suffix,
+		PreBuild:   maxCounter + 1,
+	}, nil
 }
 
 // Latest returns the highest version from the given slice.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -85,6 +85,16 @@ func (v Version) IsPrerelease() bool {
 	return v.Prerelease != ""
 }
 
+// ValidScope reports whether scope is a recognized bump level.
+func ValidScope(scope string) bool {
+	switch scope {
+	case "major", "minor", "patch":
+		return true
+	default:
+		return false
+	}
+}
+
 // Bump returns a new Version with the given scope incremented.
 // Valid scopes are "major", "minor", and "patch". Higher components
 // reset lower ones to zero (e.g. bumping minor resets patch).

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -8,13 +8,24 @@ func TestParse(t *testing.T) {
 		want    Version
 		wantErr bool
 	}{
-		{"1.2.3", Version{1, 2, 3}, false},
-		{"0.0.0", Version{0, 0, 0}, false},
-		{"10.20.30", Version{10, 20, 30}, false},
-		{"v1.2.3", Version{1, 2, 3}, false},
+		// Stable (existing cases, updated to named fields)
+		{"1.2.3", Version{Major: 1, Minor: 2, Patch: 3}, false},
+		{"0.0.0", Version{Major: 0, Minor: 0, Patch: 0}, false},
+		{"10.20.30", Version{Major: 10, Minor: 20, Patch: 30}, false},
+		{"v1.2.3", Version{Major: 1, Minor: 2, Patch: 3}, false},
+		// Prerelease
+		{"1.0.1-beta.1", Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "beta", PreBuild: 1}, false},
+		{"v1.0.1-beta.1", Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "beta", PreBuild: 1}, false},
+		{"2.3.4-rc.10", Version{Major: 2, Minor: 3, Patch: 4, Prerelease: "rc", PreBuild: 10}, false},
+		{"0.1.0-alpha.1", Version{Major: 0, Minor: 1, Patch: 0, Prerelease: "alpha", PreBuild: 1}, false},
+		// Invalid
 		{"invalid", Version{}, true},
 		{"1.2", Version{}, true},
 		{"1.2.3.4", Version{}, true},
+		{"1.0.1-beta", Version{}, true},    // missing counter
+		{"1.0.1-.1", Version{}, true},      // empty suffix
+		{"1.0.1-BETA.1", Version{}, true},  // uppercase
+		{"1.0.1-be-ta.1", Version{}, true}, // dash in suffix
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -30,15 +41,42 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestString(t *testing.T) {
+	tests := []struct {
+		v    Version
+		want string
+	}{
+		{Version{Major: 1, Minor: 2, Patch: 3}, "1.2.3"},
+		{Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "beta", PreBuild: 1}, "1.0.1-beta.1"},
+		{Version{Major: 0, Minor: 1, Patch: 0, Prerelease: "rc", PreBuild: 5}, "0.1.0-rc.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.v.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPrerelease(t *testing.T) {
+	if (Version{Major: 1, Minor: 0, Patch: 0}).IsPrerelease() {
+		t.Error("stable version should not be prerelease")
+	}
+	if !(Version{Major: 1, Minor: 0, Patch: 0, Prerelease: "beta", PreBuild: 1}).IsPrerelease() {
+		t.Error("prerelease version should be prerelease")
+	}
+}
+
 func TestBump(t *testing.T) {
-	v := Version{1, 2, 3}
+	v := Version{Major: 1, Minor: 2, Patch: 3}
 	tests := []struct {
 		scope string
 		want  Version
 	}{
-		{"major", Version{2, 0, 0}},
-		{"minor", Version{1, 3, 0}},
-		{"patch", Version{1, 2, 4}},
+		{"major", Version{Major: 2}},
+		{"minor", Version{Major: 1, Minor: 3}},
+		{"patch", Version{Major: 1, Minor: 2, Patch: 4}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.scope, func(t *testing.T) {
@@ -53,8 +91,22 @@ func TestBump(t *testing.T) {
 	}
 }
 
+func TestBumpClearsPrerelease(t *testing.T) {
+	v := Version{Major: 1, Minor: 0, Patch: 0, Prerelease: "beta", PreBuild: 3}
+	got, err := v.Bump("patch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Prerelease != "" || got.PreBuild != 0 {
+		t.Errorf("Bump should clear prerelease fields, got %v", got)
+	}
+	if got.Patch != 1 {
+		t.Errorf("Bump(patch) on 1.0.0-beta.3 = %v, want 1.0.1", got)
+	}
+}
+
 func TestBumpInvalidScope(t *testing.T) {
-	v := Version{1, 2, 3}
+	v := Version{Major: 1, Minor: 2, Patch: 3}
 	_, err := v.Bump("invalid")
 	if err == nil {
 		t.Error("expected error for invalid scope")
@@ -62,24 +114,25 @@ func TestBumpInvalidScope(t *testing.T) {
 }
 
 func TestFormatWithPrefix(t *testing.T) {
-	v := Version{1, 2, 3}
+	v := Version{Major: 1, Minor: 2, Patch: 3}
 	if got := v.FormatWithPrefix("v"); got != "v1.2.3" {
 		t.Errorf("FormatWithPrefix(\"v\") = %q, want %q", got, "v1.2.3")
 	}
-	if got := v.FormatWithPrefix("release-"); got != "release-1.2.3" {
-		t.Errorf("FormatWithPrefix(\"release-\") = %q, want %q", got, "release-1.2.3")
+	pre := Version{Major: 1, Minor: 0, Patch: 1, Prerelease: "beta", PreBuild: 1}
+	if got := pre.FormatWithPrefix("v"); got != "v1.0.1-beta.1" {
+		t.Errorf("FormatWithPrefix(\"v\") = %q, want %q", got, "v1.0.1-beta.1")
 	}
 }
 
 func TestLatest(t *testing.T) {
 	versions := []Version{
-		{1, 0, 0},
-		{2, 1, 0},
-		{1, 5, 3},
-		{2, 0, 9},
+		{Major: 1},
+		{Major: 2, Minor: 1},
+		{Major: 1, Minor: 5, Patch: 3},
+		{Major: 2, Minor: 0, Patch: 9},
 	}
 	got := Latest(versions)
-	want := Version{2, 1, 0}
+	want := Version{Major: 2, Minor: 1}
 	if got != want {
 		t.Errorf("Latest() = %v, want %v", got, want)
 	}
@@ -92,4 +145,112 @@ func TestLatestEmpty(t *testing.T) {
 		}
 	}()
 	Latest([]Version{})
+}
+
+func TestLessThanPrerelease(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b Version
+		want bool
+	}{
+		{
+			"prerelease < stable same base",
+			Version{Major: 1, Prerelease: "beta", PreBuild: 1},
+			Version{Major: 1},
+			true,
+		},
+		{
+			"stable > prerelease same base",
+			Version{Major: 1},
+			Version{Major: 1, Prerelease: "beta", PreBuild: 1},
+			false,
+		},
+		{
+			"beta.1 < beta.2",
+			Version{Major: 1, Prerelease: "beta", PreBuild: 1},
+			Version{Major: 1, Prerelease: "beta", PreBuild: 2},
+			true,
+		},
+		{
+			"cross version: 1.0.0-beta.1 < 2.0.0-beta.1",
+			Version{Major: 1, Prerelease: "beta", PreBuild: 1},
+			Version{Major: 2, Prerelease: "beta", PreBuild: 1},
+			true,
+		},
+		{
+			"equal versions are not less than",
+			Version{Major: 1, Minor: 2, Patch: 3},
+			Version{Major: 1, Minor: 2, Patch: 3},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.LessThan(tt.b); got != tt.want {
+				t.Errorf("%v.LessThan(%v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBumpPrerelease(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     Version
+		scope    string
+		suffix   string
+		existing []Version
+		want     Version
+	}{
+		{
+			"empty existing tags starts at 1",
+			Version{Major: 1},
+			"patch",
+			"beta",
+			nil,
+			Version{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 1},
+		},
+		{
+			"increments existing counter",
+			Version{Major: 1},
+			"patch",
+			"beta",
+			[]Version{
+				{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 1},
+				{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 2},
+			},
+			Version{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 3},
+		},
+		{
+			"ignores tags for different target",
+			Version{Major: 1},
+			"patch",
+			"beta",
+			[]Version{
+				{Major: 1, Minor: 1, Prerelease: "beta", PreBuild: 5},
+			},
+			Version{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 1},
+		},
+		{
+			"ignores tags with different suffix",
+			Version{Major: 1},
+			"patch",
+			"beta",
+			[]Version{
+				{Major: 1, Patch: 1, Prerelease: "rc", PreBuild: 3},
+			},
+			Version{Major: 1, Patch: 1, Prerelease: "beta", PreBuild: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.base.BumpPrerelease(tt.scope, tt.suffix, tt.existing)
+			if err != nil {
+				t.Fatalf("BumpPrerelease() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("BumpPrerelease() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/workflow/steps.go
+++ b/internal/workflow/steps.go
@@ -27,7 +27,7 @@ func FinishStepDefs(mainBranch string) []ui.StepDef {
 // FinishWorkflow returns a workflow function that checks CI, merges the PR,
 // switches to main, pulls, and cleans up local/remote branches.
 // The returned function can be composed with additional steps by wrapping it.
-func FinishWorkflow(g *git.Git, ghCli *gh.GH, branch, mainBranch, mergeStrategy string, force bool, merged *bool) func(context.Context, ui.StepCallbacks) error {
+func FinishWorkflow(g *git.Git, ghCli *gh.GH, branch, mainBranch, mergeStrategy string, force bool, merged *bool, totalSteps int) func(context.Context, ui.StepCallbacks) error {
 	return func(ctx context.Context, cb ui.StepCallbacks) error {
 		ctxGit := g.WithContext(ctx)
 		ctxGH := ghCli.WithContext(ctx)
@@ -75,9 +75,9 @@ func FinishWorkflow(g *git.Git, ghCli *gh.GH, branch, mainBranch, mergeStrategy 
 				cb.Fail(fmt.Sprintf("post-merge verification failed: %s", err))
 				return fmt.Errorf("post-merge verification failed: %w", err)
 			}
-			// PR is queued — skip cleanup steps
+			// PR is queued — skip remaining steps (cleanup + any appended steps).
 			cb.SkipStep("PR queued — waiting")
-			for range 4 {
+			for range totalSteps - 3 { // 3 = Check CI + Merge PR + Verify merge
 				cb.Start()
 				cb.SkipStep("PR queued — skipped")
 			}

--- a/internal/workflow/steps_test.go
+++ b/internal/workflow/steps_test.go
@@ -38,7 +38,7 @@ exit 1
 
 	r := runner.NewRunner(false, false)
 	var merged bool
-	wf := FinishWorkflow(git.New(r, repoDir), gh.New(r), "feature/test", "main", "squash", false, &merged)
+	wf := FinishWorkflow(git.New(r, repoDir), gh.New(r), "feature/test", "main", "squash", false, &merged, 7)
 
 	err := wf(context.Background(), ui.StepCallbacks{
 		Start: func() {},
@@ -188,7 +188,7 @@ exit 1
 
 	r := runner.NewRunner(false, false)
 	var merged bool
-	wf := FinishWorkflow(git.New(r, repoDir), gh.New(r), "feature/test", "main", "squash", false, &merged)
+	wf := FinishWorkflow(git.New(r, repoDir), gh.New(r), "feature/test", "main", "squash", false, &merged, 7)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -308,6 +308,18 @@ func TestStatusOnMain(t *testing.T) {
 	}
 }
 
+// runGitCmd runs a git command in dir, returns trimmed stdout, and fatals on error.
+func runGitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %s\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func TestReleaseFirstRelease(t *testing.T) {
 	binary := buildBinary(t)
 	dir := setupRepoWithRemote(t)
@@ -324,5 +336,109 @@ func TestReleaseFirstRelease(t *testing.T) {
 	}
 	if !strings.Contains(string(out), "v0.1.0") {
 		t.Errorf("expected v0.1.0 for first release, got: %s", out)
+	}
+}
+
+func TestReleasePreview(t *testing.T) {
+	binary := buildBinary(t)
+	dir := setupRepoWithRemote(t)
+
+	// Create a stable tag first
+	runGitCmd(t, dir, "tag", "v0.1.0")
+	runGitCmd(t, dir, "push", "origin", "v0.1.0")
+
+	// Run release preview
+	cmd := exec.Command(binary, "release", "preview", "--scope", "patch", "--yes")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("release preview failed: %s\n%s", err, out)
+	}
+
+	// Verify tag was created
+	tagOut := runGitCmd(t, dir, "tag", "-l", "v0.1.1-beta.1")
+	if tagOut != "v0.1.1-beta.1" {
+		t.Errorf("expected tag v0.1.1-beta.1, got %q", tagOut)
+	}
+
+	// Verify tag was pushed to remote
+	remoteOut := runGitCmd(t, dir, "ls-remote", "--tags", "origin", "v0.1.1-beta.1")
+	if !strings.Contains(remoteOut, "v0.1.1-beta.1") {
+		t.Errorf("tag not found on remote, got %q", remoteOut)
+	}
+}
+
+func TestReleasePreviewIncrementsCounter(t *testing.T) {
+	binary := buildBinary(t)
+	dir := setupRepoWithRemote(t)
+
+	runGitCmd(t, dir, "tag", "v0.1.0")
+	runGitCmd(t, dir, "push", "origin", "v0.1.0")
+
+	// First preview
+	cmd := exec.Command(binary, "release", "preview", "--scope", "patch", "--yes")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("first release preview failed: %s\n%s", err, out)
+	}
+
+	// Second preview
+	cmd = exec.Command(binary, "release", "preview", "--scope", "patch", "--yes")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("second release preview failed: %s\n%s", err, out)
+	}
+
+	// Verify counter incremented
+	tagOut := runGitCmd(t, dir, "tag", "-l", "v0.1.1-beta.2")
+	if tagOut != "v0.1.1-beta.2" {
+		t.Errorf("expected tag v0.1.1-beta.2, got %q", tagOut)
+	}
+}
+
+func TestReleasePreviewThenStable(t *testing.T) {
+	binary := buildBinary(t)
+	dir := setupRepoWithRemote(t)
+
+	runGitCmd(t, dir, "tag", "v0.1.0")
+	runGitCmd(t, dir, "push", "origin", "v0.1.0")
+
+	// Create a preview tag
+	cmd := exec.Command(binary, "release", "preview", "--scope", "patch", "--yes")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("release preview failed: %s\n%s", err, out)
+	}
+
+	// Now create a stable release — should bump from v0.1.0, not from the preview tag
+	cmd = exec.Command(binary, "release", "patch", "--yes")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("stable release failed: %s\n%s", err, out)
+	}
+
+	// Verify stable tag was created correctly
+	tagOut := runGitCmd(t, dir, "tag", "-l", "v0.1.1")
+	if tagOut != "v0.1.1" {
+		t.Errorf("expected stable tag v0.1.1, got %q", tagOut)
+	}
+}
+
+func TestReleasePreviewFreshRepo(t *testing.T) {
+	binary := buildBinary(t)
+	dir := setupRepoWithRemote(t)
+
+	// No existing tags — first preview should be v0.1.0-beta.1
+	cmd := exec.Command(binary, "release", "preview", "--yes")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("release preview failed: %s\n%s", err, out)
+	}
+
+	tagOut := runGitCmd(t, dir, "tag", "-l", "v0.1.0-beta.1")
+	if tagOut != "v0.1.0-beta.1" {
+		t.Errorf("expected tag v0.1.0-beta.1, got %q", tagOut)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `git sf release preview` command and `--preview`/`--scope` flags on `git sf feature finish` for deliberate prerelease tagging with configurable suffix (`beta`, `rc`, `alpha`) and auto-incrementing counters
- Extend Version struct, config system, git tag operations, release service, feature finish workflow, CLI wiring, config UI, and documentation
- Stable release paths remain completely untouched — hotfixes, status, and stable releases ignore preview tags

## Test plan

- [x] Unit tests: version parsing/comparison/bumping (17 tests), config fields (8 tests), git tag filtering + LatestPreviewTag (5 tests), release service preview (8 tests), feature finish preview logic (13 tests)
- [x] Integration tests: end-to-end release preview, counter increment, stable-after-preview, fresh repo
- [x] Build verification: `go build`, `feature finish --help` shows new flags, `release preview --help` works
- [x] CI workflow changes (stable.yml guard + prerelease.yml) require a follow-up commit with `workflow` scope token

🤖 Generated with [Claude Code](https://claude.com/claude-code)